### PR TITLE
Fix VITE_* build-time env vars in web Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,15 @@
 # Stage 1: build the React frontend
 FROM node:20-slim AS frontend-build
 WORKDIR /build
+
+ARG VITE_SUPABASE_URL
+ARG VITE_SUPABASE_ANON_KEY
+ARG VITE_API_BASE_URL
+
+ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
+ENV VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+
 COPY frontend/package*.json ./
 RUN npm ci --silent
 COPY frontend/ ./


### PR DESCRIPTION
## Summary

Fixes #3 — Railway-deployed frontend ships with empty Supabase URL/key and falls back to `localhost:8001` for the API, breaking auth and all data flows.

**Root cause**: Vite resolves `import.meta.env.VITE_*` at *build time* and inlines values into the static JS bundle. Railway only forwards build-time service variables to a Docker build for names declared as `ARG` in the Dockerfile. `web/Dockerfile` Stage 1 had no `ARG` declarations, so `npm run build` saw the vars as undefined and the bundle shipped with the consumer-side fallbacks (`''` and `http://localhost:8001`).

**Fix**: Add three `ARG` and three matching `ENV` lines to Stage 1 of `web/Dockerfile`, so Railway can pass `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, and `VITE_API_BASE_URL` through as `--build-arg` and Vite picks them up during `npm run build`.

## Changes

| File | Action | Lines |
|------|--------|-------|
| `web/Dockerfile` | UPDATE | +9/-0 |

```diff
 # Stage 1: build the React frontend
 FROM node:20-slim AS frontend-build
 WORKDIR /build
+
+ARG VITE_SUPABASE_URL
+ARG VITE_SUPABASE_ANON_KEY
+ARG VITE_API_BASE_URL
+
+ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
+ENV VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+
 COPY frontend/package*.json ./
 RUN npm ci --silent
 COPY frontend/ ./
```

Stage 2 (Python backend) is unchanged — these vars are not needed at the Python runtime, and multi-stage `ARG`/`ENV` are scoped to the stage they're declared in.

## Validation

All gates pass with the change in place:

| Check | Result |
|-------|--------|
| `mcp` ruff / mypy / pytest | ✅ / ✅ / ✅ (12 passed) |
| `web/backend` ruff / mypy / pytest | ✅ / ✅ / ✅ (11 passed) |
| `web/frontend` lint (eslint) | ✅ clean |
| `web/frontend` typecheck (tsc) | ✅ clean |
| `web/frontend` test (vitest) | ✅ 1/1 |
| `web/frontend` build (tsc + vite) | ✅ 504.65 kB / 147.21 kB gzip |

`scripts/gates.sh` does not build the Docker image, so gates do not — and cannot — exercise the Dockerfile fix directly. Final verification belongs to the next Railway deploy.

## Manual verification (deferred to Railway deploy)

1. Confirm `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_API_BASE_URL` are set on the Railway web service.
2. Open the deployed site → DevTools → Sources; confirm the Supabase URL / anon key / API base appear inlined in the bundle (not empty strings or `localhost:8001`).
3. Log in via Supabase from the deployed frontend; the auth call should hit the configured Supabase project.
4. Trigger an authenticated API call (e.g. `/search`) and verify it goes to the configured API base URL.

## Notes

- The Supabase anon key is a public client-side credential by design; embedding it in the JS bundle (and Docker image history) is intentional.
- Local prod-image testing: `docker build --build-arg VITE_SUPABASE_URL=... --build-arg VITE_SUPABASE_ANON_KEY=... --build-arg VITE_API_BASE_URL=... -f web/Dockerfile web/`.
- Out of scope: `web/railway.toml` (Railway already passes matching service vars as build args automatically), `scripts/gates.sh`, and any frontend source — the consumer-side fallbacks at `web/frontend/src/lib/supabase.ts:4-5` and `web/frontend/src/api/client.ts:3` are correct as-is.

Fixes #3