### PR TITLE
Fix: reformat /healthz send() to satisfy ruff E501

### DIFF
--- a/mcp/main.py
+++ b/mcp/main.py
@@ -67,7 +67,13 @@ def with_user_context(app: ASGIApp) -> ASGIApp:
             await app(scope, receive, send)
             return
         if scope.get("path") == "/healthz":
-            await send({"type": "http.response.start", "status": 200, "headers": [[b"content-type", b"application/json"]]})
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [[b"content-type", b"application/json"]],
+                }
+            )
             await send({"type": "http.response.body", "body": b'{"ok":true}'})
             return
         headers = {k.decode().lower(): v.decode() for k, v in scope.get("headers", [])}


### PR DESCRIPTION
## Summary

The `gates` job has been red on every push since `316f43c` because the `/healthz` start-response dict literal in `mcp/main.py:70` is 123 chars, exceeding the project's 100-char ruff limit (`mcp/pyproject.toml`).

This PR splits that single `send({...})` call across multiple lines so every line is ≤100 chars, with the ASGI message contents preserved byte-for-byte.

## Changes

- `mcp/main.py:70` — split the over-long `send()` dict literal across multiple lines (+7/-1).

No logic, types, headers, status, or body bytes change. The reformat is purely cosmetic to satisfy ruff `E501`.

## Root Cause

- `ruff check .` exits with code 1 in the `mcp: lint` step of `gates`.
- The single violation: `E501 Line too long (123 > 100)` at `main.py:70:101`.
- Introduced in `316f43c` ("Add /healthz endpoint to MCP ASGI middleware") — the commit added `/healthz` to fix Railway healthchecks but did not run `ruff check` locally before pushing.

## Validation

Local re-run mirrors `scripts/gates.sh` for the `mcp` component:

| Check | Command | Result |
|-------|---------|--------|
| Lint  | `cd mcp && ruff check .` | ✅ All checks passed |
| Types | `cd mcp && mypy .` (strict) | ✅ Success: no issues found in 8 source files |
| Tests | `cd mcp && pytest -q` | ✅ 12 passed |

The original `E501 Line too long (123 > 100)` at `mcp/main.py:70:101` is gone and no new violations were introduced.

## Test Plan

- [x] `cd mcp && ruff check .` clean
- [x] `cd mcp && mypy .` clean
- [x] `cd mcp && pytest -q` 12 passed
- [ ] After merge: confirm `gates` goes green on the new SHA
- [ ] After merge: confirm Railway `/healthz` healthcheck still passes (ASGI response is unchanged)

## Scope

In scope: the single-line reformat to clear the lint failure.

Out of scope: `/healthz` logic itself, other lint/typecheck/test changes, adding a pre-push ruff hook, refactoring the ASGI middleware.

Fixes #7