### PR TITLE
Fix: parse MCP_ALLOWED_HOSTS as CSV string, not pydantic list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ REQUESTY_BASE_URL=https://router.requesty.ai/v1
 # MCP server
 MCP_HOST=0.0.0.0
 MCP_PORT=8000
+# Comma-separated list of allowed Host: header values for DNS-rebinding
+# protection (prod: your Railway URL, e.g. mcp-production-37d7.up.railway.app).
+# Leave empty in dev to disable DNS-rebinding protection.
+MCP_ALLOWED_HOSTS=
 
 # Web backend
 WEB_HOST=0.0.0.0

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -24,11 +24,11 @@ if settings.sentry_dsn:
         environment="production",
     )
 
-_transport_security: TransportSecuritySettings | None
-if settings.mcp_allowed_hosts:
+_allowed_hosts = [h.strip() for h in settings.mcp_allowed_hosts.split(",") if h.strip()]
+if _allowed_hosts:
     _transport_security = TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=settings.mcp_allowed_hosts,
+        allowed_hosts=_allowed_hosts,
     )
 else:
     _transport_security = TransportSecuritySettings(enable_dns_rebinding_protection=False)

--- a/mcp/settings.py
+++ b/mcp/settings.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
 
     mcp_host: str = "0.0.0.0"
     mcp_port: int = 8000
-    mcp_allowed_hosts: list[str] = []
+    mcp_allowed_hosts: str = ""
 
 
 settings = Settings()

--- a/mcp/tests/test_settings.py
+++ b/mcp/tests/test_settings.py
@@ -1,0 +1,36 @@
+"""Regression tests for Settings env-var parsing."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_mcp_allowed_hosts_accepts_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "a.example.com,b.example.com")
+    import settings as settings_module
+
+    importlib.reload(settings_module)
+    parsed = [
+        h.strip()
+        for h in settings_module.settings.mcp_allowed_hosts.split(",")
+        if h.strip()
+    ]
+    assert parsed == ["a.example.com", "b.example.com"]
+
+
+def test_mcp_allowed_hosts_accepts_single_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "only.example.com")
+    import settings as settings_module
+
+    importlib.reload(settings_module)
+    assert settings_module.settings.mcp_allowed_hosts == "only.example.com"
+
+
+def test_mcp_allowed_hosts_default_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    import settings as settings_module
+
+    importlib.reload(settings_module)
+    assert settings_module.settings.mcp_allowed_hosts == ""

--- a/mcp/tests/test_settings.py
+++ b/mcp/tests/test_settings.py
@@ -12,11 +12,7 @@ def test_mcp_allowed_hosts_accepts_csv(monkeypatch: pytest.MonkeyPatch) -> None:
     import settings as settings_module
 
     importlib.reload(settings_module)
-    parsed = [
-        h.strip()
-        for h in settings_module.settings.mcp_allowed_hosts.split(",")
-        if h.strip()
-    ]
+    parsed = [h.strip() for h in settings_module.settings.mcp_allowed_hosts.split(",") if h.strip()]
     assert parsed == ["a.example.com", "b.example.com"]
 
 


### PR DESCRIPTION
## Summary

Fixes Railway production deploy failure on `main` (issue #10). The `mcp_allowed_hosts` field added in `68f7503` was typed as `list[str]`, which causes pydantic-settings to JSON-decode the env var. A bare hostname like `mcp-production-37d7.up.railway.app` is not valid JSON, so `Settings()` raises at module-import time, uvicorn never binds a port, Railway's `/healthz` healthcheck fails, and the container crashloops.

This PR changes the field to `str` and splits on `,` at the consumer site — mirroring the existing `CORS_ALLOW_ORIGINS` pattern in `web/backend/main.py:26-27`.

**Severity**: CRITICAL — prod MCP service is fully down.
**Complexity**: LOW — two-line behavior change in one isolated config path.

Fixes #10

## Root cause

- `mcp/settings.py:17` declared `mcp_allowed_hosts: list[str] = []`.
- pydantic-settings calls `json.loads()` on env-var values whose target type is "complex" (e.g. `list[str]`).
- Railway sets `MCP_ALLOWED_HOSTS` to a plain hostname (or CSV) — neither parses as JSON.
- `Settings()` is constructed at module top-level, so the import of `main` raises before uvicorn can bind.

Reproduced locally on the failing SHA:
```
$ MCP_ALLOWED_HOSTS=mcp-production-37d7.up.railway.app python -c 'from settings import Settings; Settings()'
pydantic_settings.exceptions.SettingsError: error parsing value for field "mcp_allowed_hosts" from source "EnvSettingsSource"
  → caused by json.decoder.JSONDecodeError
```

CI was green because no test sets `MCP_ALLOWED_HOSTS`; the default `[]` works fine. Only setting the env var trips the bug — i.e. the prod-only path.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `mcp/settings.py` | UPDATE | `mcp_allowed_hosts: list[str] = []` → `mcp_allowed_hosts: str = ""` |
| `mcp/main.py` | UPDATE | Split CSV at consumer site; drop dead `\| None` annotation on `_transport_security` |
| `.env.example` | UPDATE | Document `MCP_ALLOWED_HOSTS` env var (was missing) |
| `mcp/tests/test_settings.py` | CREATE | 3 regression tests: CSV / single value / empty default |

Total: 4 files, +44 / -4 lines.

## Validation

All gates green for files touched by this branch:

| Check | Result |
|-------|--------|
| `ruff check .` | ✅ All checks passed |
| `ruff format --check .` | ✅ Pass (1 auto-fix on new test file) |
| `mypy .` (strict) | ✅ Success: no issues found in 8 source files |
| `pytest -q` | ✅ 15 passed (3 new + 12 pre-existing) |

### Pre-fix reproduction (must FAIL)
```
$ MCP_ALLOWED_HOSTS=mcp-production-37d7.up.railway.app python -c 'from settings import Settings; Settings()'
SettingsError: error parsing value for field "mcp_allowed_hosts"
```
✅ Reproduced.

### Post-fix manual verification (must PASS)

| Command | Expected | Actual |
|---------|----------|--------|
| `MCP_ALLOWED_HOSTS=mcp-production-37d7.up.railway.app python -c '...print(_allowed_hosts)'` | `['mcp-production-37d7.up.railway.app']` | ✅ matches |
| `MCP_ALLOWED_HOSTS='a.example.com, b.example.com' python -c '...'` | `['a.example.com', 'b.example.com']` | ✅ matches |
| `unset MCP_ALLOWED_HOSTS; python -c '...'` | `[]` | ✅ matches |

## Test plan

- [x] Lint, format, mypy strict, pytest all green locally
- [x] Pre-fix repro confirmed
- [x] Post-fix repro confirmed for CSV / single / empty cases
- [ ] Watch the next Railway deploy on `main` reach `success` after merge
- [ ] `curl https://mcp-production-37d7.up.railway.app/healthz` → `{"ok":true}`
- [ ] Real MCP request from a client (e.g. Claude.ai connector) → no 421 (the original DNS-rebinding rejection that #10 was meant to fix)

## Out of scope

- Pre-existing format drift in `mcp/db.py` and `mcp/tools/entries.py` — left untouched to keep this PR scoped to #10.
- No Railway env-var change required; the new code accepts whatever string is currently set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)