### PR TITLE
Add MCP OAuth 2.1 for Claude.ai connector authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,18 @@ MCP_PORT=8000
 # Leave empty in dev to disable DNS-rebinding protection.
 MCP_ALLOWED_HOSTS=
 
+# MCP OAuth 2.1 (Claude.ai connector authentication).
+# Local dev now requires a bearer token on every /mcp/ request — unauthenticated
+# requests return 401 (previously they leaked through and crashed). Use either a
+# connector token (mint via the web backend's POST /connect/token) or the
+# OAuth flow below.
+# Public base URL of the MCP server (no trailing slash). Used to build
+# the absolute URLs in /.well-known/oauth-* discovery responses.
+MCP_BASE_URL=https://kindred-mcp.interstellarai.net
+# HS256 secret for signing/validating server-issued JWTs. Generate via
+# `python -c "import secrets; print(secrets.token_urlsafe(32))"`.
+SECRET_KEY=
+
 # Web backend
 WEB_HOST=0.0.0.0
 WEB_PORT=8001

--- a/mcp/auth.py
+++ b/mcp/auth.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 import asyncio
 from contextvars import ContextVar
 
+import jwt
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 
 import db
+from settings import settings
 
 current_user_id: ContextVar[str] = ContextVar("current_user_id")
 
@@ -47,3 +49,19 @@ async def resolve_user_id(token: str) -> str | None:
     if row is None:
         return None
     return str(row["user_id"])
+
+
+def resolve_user_id_from_jwt(token: str) -> str | None:
+    """Decode an HS256 JWT signed with ``settings.secret_key``.
+
+    Returns the ``sub`` claim (user_id) or ``None`` if verification fails for
+    any reason (missing secret, expired token, bad signature, malformed payload).
+    """
+    if not settings.secret_key:
+        return None
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+    except jwt.PyJWTError:
+        return None
+    sub = payload.get("sub")
+    return str(sub) if sub else None

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -10,7 +10,7 @@ import sentry_sdk
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from auth import current_user_id, resolve_user_id
+from auth import current_user_id, resolve_user_id, resolve_user_id_from_jwt
 from settings import settings
 from tools import entries as entry_tools
 from tools import patterns as pattern_tools
@@ -39,6 +39,14 @@ mcp: FastMCP = FastMCP(
     json_response=True,
     transport_security=_transport_security,
 )
+
+# ---------------------------------------------------------------------------
+# OAuth 2.1 + discovery routes (registered as @mcp.custom_route())
+# ---------------------------------------------------------------------------
+from oauth import register_routes as _register_oauth_routes  # noqa: E402
+
+_register_oauth_routes(mcp)
+
 
 # ---------------------------------------------------------------------------
 # Tool registration
@@ -81,12 +89,20 @@ Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
 ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
 
 
+_PUBLIC_PATH_PREFIXES = ("/.well-known/", "/oauth/")
+
+
+def _is_public_path(path: str) -> bool:
+    return any(path.startswith(p) for p in _PUBLIC_PATH_PREFIXES)
+
+
 def with_user_context(app: ASGIApp) -> ASGIApp:
     async def wrapper(scope: Scope, receive: Receive, send: Send) -> None:
         if scope.get("type") != "http":
             await app(scope, receive, send)
             return
-        if scope.get("path") == "/healthz":
+        path = scope.get("path", "")
+        if path == "/healthz":
             await send(
                 {
                     "type": "http.response.start",
@@ -96,21 +112,52 @@ def with_user_context(app: ASGIApp) -> ASGIApp:
             )
             await send({"type": "http.response.body", "body": b'{"ok":true}'})
             return
+        if _is_public_path(path):
+            # OAuth + discovery endpoints are intentionally unauthenticated;
+            # let FastMCP's custom_route handlers serve them.
+            await app(scope, receive, send)
+            return
         headers = {k.decode().lower(): v.decode() for k, v in scope.get("headers", [])}
         auth = headers.get("authorization", "")
         token: str | None = None
         if auth.lower().startswith("bearer "):
             token = auth.split(" ", 1)[1].strip()
+
+        user_id: str | None = None
         if token:
-            user_id = await resolve_user_id(token)
-            if user_id is not None:
-                ctx_token = current_user_id.set(user_id)
-                try:
-                    await app(scope, receive, send)
-                finally:
-                    current_user_id.reset(ctx_token)
-                return
-        await app(scope, receive, send)
+            # JWTs always start with "eyJ" (base64 of '{"...'); try JWT first,
+            # then fall through to the connector-token DB lookup.
+            if token.startswith("eyJ"):
+                user_id = resolve_user_id_from_jwt(token)
+            if user_id is None:
+                user_id = await resolve_user_id(token)
+
+        if user_id is not None:
+            ctx_token = current_user_id.set(user_id)
+            try:
+                await app(scope, receive, send)
+            finally:
+                current_user_id.reset(ctx_token)
+            return
+
+        # Unauthenticated request to a protected path → 401 with the
+        # RFC 9728 resource_metadata pointer so MCP clients can discover
+        # the OAuth flow. Public OAuth/discovery routes are served by
+        # FastMCP's custom_route registration before middleware reaches them.
+        base = settings.mcp_base_url.rstrip("/") if settings.mcp_base_url else ""
+        resource_metadata_url = f"{base}/.well-known/oauth-protected-resource"
+        www_auth = f'Bearer realm="kindred", resource_metadata="{resource_metadata_url}"'
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    [b"content-type", b"application/json"],
+                    [b"www-authenticate", www_auth.encode("ascii")],
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"error":"unauthorized"}'})
 
     return wrapper
 

--- a/mcp/oauth.py
+++ b/mcp/oauth.py
@@ -1,0 +1,442 @@
+"""OAuth 2.1 endpoints for the Kindred MCP server.
+
+Implements the MCP Authorization spec
+(https://modelcontextprotocol.io/specification/draft/basic/authorization):
+
+  - GET  /.well-known/oauth-protected-resource     (RFC 9728)
+  - GET  /.well-known/oauth-authorization-server   (RFC 8414)
+  - POST /oauth/register                            (RFC 7591)
+  - GET  /oauth/authorize  → 302 to Supabase Google OAuth (PKCE)
+  - GET  /oauth/callback   ← receives Supabase code, exchanges for user info
+  - POST /oauth/token      → issues HS256 JWT (and refresh token)
+
+Routes are registered as ``@mcp.custom_route()`` on the FastMCP instance via
+``register_routes(mcp_obj)`` — invoked from ``main.py`` after the FastMCP
+instance is constructed (avoids circular imports).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+import jwt
+from mcp.server.fastmcp import FastMCP
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+
+from oauth_state import (
+    auth_codes,
+    cleanup_and_pop,
+    cleanup_and_store,
+    oauth_sessions,
+    refresh_tokens,
+    registered_clients,
+)
+from settings import settings
+
+logger = logging.getLogger(__name__)
+
+AUTH_CODE_TTL_SECONDS = 60 * 10  # 10 minutes
+SESSION_TTL_SECONDS = 60 * 10  # 10 minutes
+JWT_EXPIRY_SECONDS = 60 * 60 * 24 * 7  # 7 days
+REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30  # 30 days
+
+
+def _base_url() -> str:
+    """Public base URL of the MCP server (no trailing slash). Raises 501 if unset."""
+    if not settings.mcp_base_url:
+        raise HTTPException(status_code=501, detail="MCP_BASE_URL not configured")
+    return settings.mcp_base_url.rstrip("/")
+
+
+def _supabase_authorize_url(server_state: str, code_challenge: str) -> str:
+    """Build the Supabase Auth URL that starts the Google OAuth + PKCE flow."""
+    if not settings.supabase_url:
+        raise HTTPException(status_code=501, detail="SUPABASE_URL not configured")
+    base = settings.supabase_url.rstrip("/")
+    redirect_to = f"{_base_url()}/oauth/callback"
+    params = {
+        "provider": "google",
+        "redirect_to": redirect_to,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": server_state,
+    }
+    return f"{base}/auth/v1/authorize?{urlencode(params)}"
+
+
+def _create_jwt(user_id: str, email: str | None) -> str:
+    """Mint an HS256 JWT signed with ``settings.secret_key``."""
+    now = datetime.now(UTC)
+    payload: dict[str, Any] = {
+        "sub": user_id,
+        "iat": int(now.timestamp()),
+        "exp": int(now.timestamp()) + JWT_EXPIRY_SECONDS,
+    }
+    if email:
+        payload["email"] = email
+    return jwt.encode(payload, settings.secret_key, algorithm="HS256")
+
+
+def _pkce_s256(verifier: str) -> str:
+    """Compute ``BASE64URL(SHA256(verifier))`` with no padding (RFC 7636 §4.6)."""
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _issue_token_response(
+    user_id: str, email: str | None, client_id: str, scope: str
+) -> JSONResponse:
+    """RFC 6749 token response with a fresh access_token + rotated refresh_token."""
+    if not settings.secret_key:
+        raise HTTPException(status_code=501, detail="SECRET_KEY not configured")
+
+    access_token = _create_jwt(user_id, email)
+    refresh_token = secrets.token_urlsafe(32)
+    cleanup_and_store(
+        refresh_tokens,
+        refresh_token,
+        {
+            "user_id": user_id,
+            "email": email,
+            "client_id": client_id,
+            "scope": scope,
+            "expires_at": datetime.now(UTC)
+            + timedelta(seconds=REFRESH_TOKEN_TTL_SECONDS),
+        },
+    )
+    return JSONResponse(
+        {
+            "access_token": access_token,
+            "token_type": "bearer",
+            "expires_in": JWT_EXPIRY_SECONDS,
+            "refresh_token": refresh_token,
+            "scope": scope,
+        }
+    )
+
+
+def register_routes(mcp_obj: FastMCP) -> None:
+    """Register all OAuth + discovery routes on the given FastMCP instance.
+
+    Called from ``main.py`` after ``mcp = FastMCP(...)`` is constructed. Using
+    a function (rather than module-level decorators) avoids the ``main → oauth
+    → main`` circular import that would otherwise occur.
+    """
+
+    # -----------------------------------------------------------------------
+    # RFC 9728: Protected Resource Metadata
+    # -----------------------------------------------------------------------
+    @mcp_obj.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])  # type: ignore[untyped-decorator]
+    async def protected_resource_metadata(_request: Request) -> Response:
+        base = _base_url()
+        return JSONResponse(
+            {
+                "resource": f"{base}/mcp/",
+                "authorization_servers": [base],
+                "scopes_supported": ["mcp"],
+            }
+        )
+
+    # -----------------------------------------------------------------------
+    # RFC 8414: Authorization Server Metadata
+    # -----------------------------------------------------------------------
+    @mcp_obj.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])  # type: ignore[untyped-decorator]
+    async def authorization_server_metadata(_request: Request) -> Response:
+        base = _base_url()
+        return JSONResponse(
+            {
+                "issuer": base,
+                "authorization_endpoint": f"{base}/oauth/authorize",
+                "token_endpoint": f"{base}/oauth/token",
+                "registration_endpoint": f"{base}/oauth/register",
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "code_challenge_methods_supported": ["S256"],
+                "scopes_supported": ["mcp"],
+            }
+        )
+
+    # -----------------------------------------------------------------------
+    # RFC 7591: Dynamic Client Registration
+    # -----------------------------------------------------------------------
+    @mcp_obj.custom_route("/oauth/register", methods=["POST"])  # type: ignore[untyped-decorator]
+    async def oauth_register(request: Request) -> Response:
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict):
+            body = {}
+
+        client_id = uuid.uuid4().hex
+        client_secret = secrets.token_urlsafe(32)
+        client = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uris": body.get("redirect_uris", []),
+            "client_name": body.get("client_name", ""),
+            "grant_types": body.get("grant_types", ["authorization_code"]),
+            "response_types": body.get("response_types", ["code"]),
+            "token_endpoint_auth_method": body.get(
+                "token_endpoint_auth_method", "client_secret_post"
+            ),
+            "scope": body.get("scope", "mcp"),
+        }
+        cleanup_and_store(registered_clients, client_id, client)
+        logger.info(
+            "MCP OAuth: registered client %s (%s)",
+            client_id,
+            client["client_name"],
+        )
+        return JSONResponse(
+            {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uris": client["redirect_uris"],
+                "client_name": client["client_name"],
+                "grant_types": client["grant_types"],
+                "response_types": client["response_types"],
+                "token_endpoint_auth_method": client["token_endpoint_auth_method"],
+                "scope": client["scope"],
+            },
+            status_code=201,
+        )
+
+    # -----------------------------------------------------------------------
+    # Authorization endpoint
+    # -----------------------------------------------------------------------
+    @mcp_obj.custom_route("/oauth/authorize", methods=["GET"])  # type: ignore[untyped-decorator]
+    async def oauth_authorize(request: Request) -> Response:
+        if not settings.secret_key:
+            raise HTTPException(status_code=501, detail="SECRET_KEY not configured")
+        if not settings.supabase_url:
+            raise HTTPException(status_code=501, detail="SUPABASE_URL not configured")
+
+        qp = request.query_params
+        client_id = qp.get("client_id", "")
+        redirect_uri = qp.get("redirect_uri", "")
+        client_state = qp.get("state", "")
+        code_challenge = qp.get("code_challenge", "")
+        code_challenge_method = qp.get("code_challenge_method", "S256")
+        scope = qp.get("scope", "mcp")
+        response_type = qp.get("response_type", "code")
+
+        if response_type != "code":
+            raise HTTPException(
+                status_code=400, detail="Only response_type=code is supported"
+            )
+        if code_challenge_method != "S256":
+            raise HTTPException(
+                status_code=400,
+                detail="Only code_challenge_method=S256 is supported",
+            )
+        if not redirect_uri:
+            raise HTTPException(status_code=400, detail="redirect_uri is required")
+        if not code_challenge:
+            raise HTTPException(
+                status_code=400, detail="code_challenge is required (PKCE required)"
+            )
+        registered = registered_clients.get(client_id)
+        if not registered:
+            raise HTTPException(
+                status_code=400,
+                detail="Unknown client_id — register first via POST /oauth/register",
+            )
+        if redirect_uri not in registered.get("redirect_uris", []):
+            raise HTTPException(
+                status_code=400, detail="redirect_uri not registered for this client"
+            )
+
+        server_state = secrets.token_urlsafe(32)
+        supabase_code_verifier = secrets.token_urlsafe(64)
+        supabase_code_challenge = _pkce_s256(supabase_code_verifier)
+
+        cleanup_and_store(
+            oauth_sessions,
+            server_state,
+            {
+                "client_state": client_state,
+                "redirect_uri": redirect_uri,
+                "code_challenge": code_challenge,
+                "code_challenge_method": code_challenge_method,
+                "client_id": client_id,
+                "scope": scope,
+                "supabase_code_verifier": supabase_code_verifier,
+                "expires_at": datetime.now(UTC)
+                + timedelta(seconds=SESSION_TTL_SECONDS),
+            },
+        )
+        logger.info(
+            "MCP OAuth: authorize redirect for client %s → Supabase",
+            client_id,
+        )
+        return RedirectResponse(
+            url=_supabase_authorize_url(server_state, supabase_code_challenge),
+            status_code=302,
+        )
+
+    # -----------------------------------------------------------------------
+    # OAuth callback (Supabase → kindred)
+    # -----------------------------------------------------------------------
+    @mcp_obj.custom_route("/oauth/callback", methods=["GET"])  # type: ignore[untyped-decorator]
+    async def oauth_callback(request: Request) -> Response:
+        qp = request.query_params
+        supabase_code = qp.get("code", "")
+        server_state = qp.get("state", "")
+
+        session = cleanup_and_pop(oauth_sessions, server_state)
+        if not session:
+            raise HTTPException(
+                status_code=400, detail="Invalid or expired session state"
+            )
+
+        client_redirect_uri = session["redirect_uri"]
+        client_state = session["client_state"]
+
+        def _redirect(params: dict[str, str]) -> RedirectResponse:
+            return RedirectResponse(
+                url=f"{client_redirect_uri}?{urlencode(params)}",
+                status_code=302,
+            )
+
+        if not supabase_code:
+            return _redirect({"error": "invalid_request", "state": client_state})
+
+        # Exchange Supabase auth code for an access token via PKCE.
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(
+                    f"{settings.supabase_url.rstrip('/')}/auth/v1/token",
+                    params={"grant_type": "pkce"},
+                    json={
+                        "auth_code": supabase_code,
+                        "code_verifier": session["supabase_code_verifier"],
+                    },
+                    headers={
+                        "apikey": settings.supabase_anon_key,
+                        "Content-Type": "application/json",
+                    },
+                )
+            if resp.status_code != 200:
+                logger.warning(
+                    "MCP OAuth: Supabase token exchange failed: status=%s",
+                    resp.status_code,
+                )
+                return _redirect({"error": "server_error", "state": client_state})
+            token_payload = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.warning("MCP OAuth: Supabase token exchange error: %s", exc)
+            return _redirect({"error": "server_error", "state": client_state})
+
+        access_token = token_payload.get("access_token", "")
+        if not access_token:
+            return _redirect({"error": "server_error", "state": client_state})
+
+        try:
+            claims = jwt.decode(
+                access_token,
+                settings.supabase_jwt_secret,
+                audience="authenticated",
+                algorithms=["HS256"],
+            )
+        except jwt.PyJWTError as exc:
+            logger.warning("MCP OAuth: Supabase JWT decode failed: %s", exc)
+            return _redirect({"error": "server_error", "state": client_state})
+
+        user_id = claims.get("sub")
+        email = claims.get("email")
+        if not user_id:
+            return _redirect({"error": "server_error", "state": client_state})
+
+        # Mint our own auth code; bind to the MCP client's PKCE challenge.
+        kindred_auth_code = secrets.token_urlsafe(32)
+        cleanup_and_store(
+            auth_codes,
+            kindred_auth_code,
+            {
+                "user_id": str(user_id),
+                "email": email,
+                "code_challenge": session["code_challenge"],
+                "code_challenge_method": session["code_challenge_method"],
+                "redirect_uri": client_redirect_uri,
+                "scope": session.get("scope", "mcp"),
+                "client_id": session["client_id"],
+                "expires_at": datetime.now(UTC)
+                + timedelta(seconds=AUTH_CODE_TTL_SECONDS),
+            },
+        )
+        logger.info(
+            "MCP OAuth: callback complete; redirecting to client %s",
+            session["client_id"],
+        )
+        return _redirect({"code": kindred_auth_code, "state": client_state})
+
+    # -----------------------------------------------------------------------
+    # Token endpoint
+    # -----------------------------------------------------------------------
+    @mcp_obj.custom_route("/oauth/token", methods=["POST"])  # type: ignore[untyped-decorator]
+    async def oauth_token(request: Request) -> Response:
+        if not settings.secret_key:
+            raise HTTPException(status_code=501, detail="SECRET_KEY not configured")
+
+        form = await request.form()
+        grant_type = str(form.get("grant_type", ""))
+
+        if grant_type == "refresh_token":
+            refresh_token = str(form.get("refresh_token", ""))
+            if not refresh_token:
+                raise HTTPException(
+                    status_code=400, detail="refresh_token is required"
+                )
+            session = cleanup_and_pop(refresh_tokens, refresh_token)
+            if not session:
+                raise HTTPException(
+                    status_code=400, detail="Invalid or expired refresh_token"
+                )
+            return _issue_token_response(
+                session["user_id"],
+                session.get("email"),
+                session["client_id"],
+                session.get("scope", "mcp"),
+            )
+
+        if grant_type != "authorization_code":
+            raise HTTPException(status_code=400, detail="Unsupported grant_type")
+
+        code = str(form.get("code", ""))
+        redirect_uri = str(form.get("redirect_uri", ""))
+        client_id = str(form.get("client_id", ""))
+        code_verifier = str(form.get("code_verifier", ""))
+
+        session = cleanup_and_pop(auth_codes, code)
+        if not session:
+            raise HTTPException(
+                status_code=400, detail="Invalid or expired authorization code"
+            )
+        if redirect_uri != session["redirect_uri"]:
+            raise HTTPException(status_code=400, detail="redirect_uri mismatch")
+
+        if session.get("code_challenge_method") == "S256":
+            if not code_verifier:
+                raise HTTPException(
+                    status_code=400, detail="code_verifier is required"
+                )
+            if _pkce_s256(code_verifier) != session["code_challenge"]:
+                raise HTTPException(status_code=400, detail="PKCE verification failed")
+
+        return _issue_token_response(
+            session["user_id"],
+            session.get("email"),
+            client_id or session.get("client_id", ""),
+            session.get("scope", "mcp"),
+        )

--- a/mcp/oauth_state.py
+++ b/mcp/oauth_state.py
@@ -1,0 +1,103 @@
+"""Shared in-memory state for the MCP OAuth 2.1 flow.
+
+Four bounded dicts back the seven endpoints in ``oauth.py``. Expired entries
+are lazily purged on every store/retrieve, and each dict is hard-capped at
+``MAX_ENTRIES_PER_DICT`` to avoid unbounded growth. Persistence is intentionally
+not implemented — Railway redeploys are infrequent enough that re-registering
+on restart is acceptable.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+MAX_ENTRIES_PER_DICT = 10_000
+
+# Lock protecting all mutable state dicts below against concurrent access
+# from threadpool-dispatched sync endpoints.
+_state_lock = threading.Lock()
+
+Entry = dict[str, Any]
+
+# server_state -> {
+#   client_state, redirect_uri, code_challenge, code_challenge_method,
+#   client_id, scope, supabase_code_verifier, expires_at
+# }
+oauth_sessions: dict[str, Entry] = {}
+
+# auth_code -> {
+#   user_id, email, code_challenge, code_challenge_method, redirect_uri, expires_at
+# }
+auth_codes: dict[str, Entry] = {}
+
+# client_id -> {
+#   client_id, client_secret, redirect_uris, client_name, grant_types,
+#   response_types, token_endpoint_auth_method, scope
+# }
+registered_clients: dict[str, Entry] = {}
+
+# refresh_token -> {
+#   user_id, email, client_id, scope, expires_at
+# }
+refresh_tokens: dict[str, Entry] = {}
+
+
+def _is_expired(entry: Entry, now_ts: float, now_dt: datetime) -> bool:
+    exp = entry.get("expires_at")
+    if exp is None:
+        return False
+    if isinstance(exp, datetime):
+        return now_dt > exp
+    # numeric (epoch seconds)
+    return bool(now_ts > exp)
+
+
+def _cleanup_expired(store: dict[str, Entry]) -> None:
+    """Remove entries whose ``expires_at`` is in the past.
+
+    Entries may store ``expires_at`` as either a timezone-aware ``datetime``
+    or a ``float`` (Unix epoch). Entries without ``expires_at`` (e.g.
+    registered clients) are never evicted by this function.
+    """
+    now_ts = time.time()
+    now_dt = datetime.now(UTC)
+    expired_keys = [k for k, v in store.items() if _is_expired(v, now_ts, now_dt)]
+    for k in expired_keys:
+        del store[k]
+    if expired_keys:
+        logger.debug("oauth_state: purged %d expired entries", len(expired_keys))
+
+
+class StoreFullError(Exception):
+    """Raised when a bounded dict exceeds MAX_ENTRIES_PER_DICT after cleanup."""
+
+
+def cleanup_and_store(store: dict[str, Entry], key: str, value: Entry) -> None:
+    """Purge expired entries, enforce size cap, then insert *key*: *value*."""
+    with _state_lock:
+        _cleanup_expired(store)
+        if len(store) >= MAX_ENTRIES_PER_DICT:
+            raise StoreFullError(
+                f"OAuth state store is full ({MAX_ENTRIES_PER_DICT} entries)"
+            )
+        store[key] = value
+
+
+def cleanup_and_get(store: dict[str, Entry], key: str) -> Entry | None:
+    """Purge expired entries, then return the entry for *key* (or ``None``)."""
+    with _state_lock:
+        _cleanup_expired(store)
+        return store.get(key)
+
+
+def cleanup_and_pop(store: dict[str, Entry], key: str) -> Entry | None:
+    """Purge expired entries, then pop and return the entry for *key* (or ``None``)."""
+    with _state_lock:
+        _cleanup_expired(store)
+        return store.pop(key, None)

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -7,3 +7,5 @@ pydantic>=2.9
 pydantic-settings>=2.6
 python-dotenv>=1.0
 sentry-sdk[fastapi]>=2.0
+pyjwt>=2.8
+httpx>=0.27

--- a/mcp/settings.py
+++ b/mcp/settings.py
@@ -12,6 +12,11 @@ class Settings(BaseSettings):
 
     sentry_dsn: str = ""
 
+    supabase_anon_key: str = ""
+    supabase_jwt_secret: str = ""
+    mcp_base_url: str = ""
+    secret_key: str = ""
+
     mcp_host: str = "0.0.0.0"
     mcp_port: int = 8000
     mcp_allowed_hosts: str = ""

--- a/mcp/tests/test_auth.py
+++ b/mcp/tests/test_auth.py
@@ -1,13 +1,20 @@
-"""Tests for ConnectorTokenVerifier."""
+"""Tests for ConnectorTokenVerifier + JWT auth helpers + middleware 401."""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import httpx
+import jwt
 import pytest
 
 import db
-from auth import ConnectorTokenVerifier
+import settings as settings_module
+from auth import ConnectorTokenVerifier, resolve_user_id_from_jwt
+
+SECRET = "test-secret-needs-to-be-at-least-32-bytes-long"
+USER_ID = "11111111-2222-3333-4444-555555555555"
 
 
 @pytest.mark.asyncio
@@ -33,3 +40,70 @@ async def test_verify_token_known_returns_access_token(
     assert token.client_id == user_id
     assert token.scopes == ["user"]
     assert token.expires_at is None
+
+
+# ---------------------------------------------------------------------------
+# JWT helper
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_user_id_from_jwt_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_module.settings, "secret_key", SECRET)
+    token = jwt.encode(
+        {"sub": USER_ID, "exp": int((datetime.now(UTC) + timedelta(hours=1)).timestamp())},
+        SECRET,
+        algorithm="HS256",
+    )
+    assert resolve_user_id_from_jwt(token) == USER_ID
+
+
+def test_resolve_user_id_from_jwt_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_module.settings, "secret_key", SECRET)
+    token = jwt.encode(
+        {"sub": USER_ID, "exp": int((datetime.now(UTC) - timedelta(hours=1)).timestamp())},
+        SECRET,
+        algorithm="HS256",
+    )
+    assert resolve_user_id_from_jwt(token) is None
+
+
+def test_resolve_user_id_from_jwt_wrong_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_module.settings, "secret_key", SECRET)
+    other = "another-secret-also-needs-to-be-at-least-32-bytes"
+    token = jwt.encode({"sub": USER_ID}, other, algorithm="HS256")
+    assert resolve_user_id_from_jwt(token) is None
+
+
+def test_resolve_user_id_from_jwt_no_secret_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings_module.settings, "secret_key", "")
+    token = jwt.encode({"sub": USER_ID}, "anything-32-bytes-long-here-okay-yes", algorithm="HS256")
+    assert resolve_user_id_from_jwt(token) is None
+
+
+# ---------------------------------------------------------------------------
+# Middleware: 401 + WWW-Authenticate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_middleware_returns_401_with_www_authenticate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings_module.settings, "mcp_base_url", "https://test.example.com"
+    )
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        res = await c.post("/mcp/")
+    assert res.status_code == 401
+    www_auth = res.headers.get("www-authenticate", "")
+    assert www_auth.startswith("Bearer realm=")
+    assert (
+        'resource_metadata="https://test.example.com/.well-known/oauth-protected-resource"'
+        in www_auth
+    )

--- a/mcp/tests/test_oauth_authorize_token.py
+++ b/mcp/tests/test_oauth_authorize_token.py
@@ -1,0 +1,289 @@
+"""Authorize → Token end-to-end tests (PKCE + refresh-token rotation)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import jwt
+import pytest
+
+import oauth_state
+import settings as settings_module
+from main import app
+
+SECRET = "test-secret-do-not-use-in-prod-needs-32-bytes-minimum"
+SUPABASE_URL = "https://supabase.test"
+BASE = "https://test.example.com"
+USER_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    return verifier, challenge
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_base_url", BASE)
+    monkeypatch.setattr(settings_module.settings, "secret_key", SECRET)
+    monkeypatch.setattr(settings_module.settings, "supabase_url", SUPABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def _clear_state() -> None:
+    oauth_state.registered_clients.clear()
+    oauth_state.oauth_sessions.clear()
+    oauth_state.auth_codes.clear()
+    oauth_state.refresh_tokens.clear()
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+async def _register(client: httpx.AsyncClient, redirect: str = "https://app/cb") -> str:
+    res = await client.post(
+        "/oauth/register",
+        json={"client_name": "test", "redirect_uris": [redirect]},
+    )
+    assert res.status_code == 201
+    return str(res.json()["client_id"])
+
+
+# ---------------------------------------------------------------------------
+# /oauth/authorize
+# ---------------------------------------------------------------------------
+
+
+async def test_authorize_redirects_to_supabase(client: httpx.AsyncClient) -> None:
+    cid = await _register(client)
+    _verifier, challenge = _pkce_pair()
+    res = await client.get(
+        "/oauth/authorize",
+        params={
+            "client_id": cid,
+            "redirect_uri": "https://app/cb",
+            "state": "client-state-123",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "response_type": "code",
+            "scope": "mcp",
+        },
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    loc = res.headers["location"]
+    assert loc.startswith(f"{SUPABASE_URL}/auth/v1/authorize?")
+    qs = parse_qs(urlparse(loc).query)
+    assert qs["provider"] == ["google"]
+    assert qs["code_challenge_method"] == ["S256"]
+    assert qs["redirect_to"] == [f"{BASE}/oauth/callback"]
+    assert "state" in qs
+    # Server state must be stored in the sessions dict
+    server_state = qs["state"][0]
+    assert server_state in oauth_state.oauth_sessions
+    assert oauth_state.oauth_sessions[server_state]["client_state"] == "client-state-123"
+
+
+async def test_authorize_rejects_unknown_redirect_uri(client: httpx.AsyncClient) -> None:
+    cid = await _register(client, redirect="https://app/cb")
+    _v, challenge = _pkce_pair()
+    res = await client.get(
+        "/oauth/authorize",
+        params={
+            "client_id": cid,
+            "redirect_uri": "https://evil.com/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        },
+        follow_redirects=False,
+    )
+    assert res.status_code == 400
+
+
+async def test_authorize_rejects_missing_code_challenge(client: httpx.AsyncClient) -> None:
+    cid = await _register(client)
+    res = await client.get(
+        "/oauth/authorize",
+        params={
+            "client_id": cid,
+            "redirect_uri": "https://app/cb",
+            "code_challenge_method": "S256",
+        },
+        follow_redirects=False,
+    )
+    assert res.status_code == 400
+
+
+async def test_authorize_rejects_plain_pkce(client: httpx.AsyncClient) -> None:
+    cid = await _register(client)
+    _v, challenge = _pkce_pair()
+    res = await client.get(
+        "/oauth/authorize",
+        params={
+            "client_id": cid,
+            "redirect_uri": "https://app/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "plain",
+        },
+        follow_redirects=False,
+    )
+    assert res.status_code == 400
+
+
+async def test_authorize_rejects_unknown_client_id(client: httpx.AsyncClient) -> None:
+    _v, challenge = _pkce_pair()
+    res = await client.get(
+        "/oauth/authorize",
+        params={
+            "client_id": "does-not-exist",
+            "redirect_uri": "https://app/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        },
+        follow_redirects=False,
+    )
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /oauth/token (authorization_code)
+# ---------------------------------------------------------------------------
+
+
+def _seed_auth_code(*, code: str, verifier: str, redirect_uri: str) -> None:
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    oauth_state.auth_codes[code] = {
+        "user_id": USER_ID,
+        "email": "u@example.com",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "redirect_uri": redirect_uri,
+        "scope": "mcp",
+        "client_id": "test-client",
+        "expires_at": datetime.now(UTC) + timedelta(minutes=5),
+    }
+
+
+async def test_token_authorization_code_returns_jwt(client: httpx.AsyncClient) -> None:
+    verifier, _ = _pkce_pair()
+    _seed_auth_code(code="ac-1", verifier=verifier, redirect_uri="https://app/cb")
+    res = await client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": "ac-1",
+            "redirect_uri": "https://app/cb",
+            "code_verifier": verifier,
+            "client_id": "test-client",
+        },
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["token_type"] == "bearer"
+    assert "access_token" in body and "refresh_token" in body
+    claims = jwt.decode(body["access_token"], SECRET, algorithms=["HS256"])
+    assert claims["sub"] == USER_ID
+    assert claims["email"] == "u@example.com"
+
+
+async def test_token_rejects_wrong_verifier(client: httpx.AsyncClient) -> None:
+    verifier, _ = _pkce_pair()
+    _seed_auth_code(code="ac-2", verifier=verifier, redirect_uri="https://app/cb")
+    res = await client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": "ac-2",
+            "redirect_uri": "https://app/cb",
+            "code_verifier": "the-wrong-verifier",
+        },
+    )
+    assert res.status_code == 400
+
+
+async def test_token_rejects_redirect_uri_mismatch(client: httpx.AsyncClient) -> None:
+    verifier, _ = _pkce_pair()
+    _seed_auth_code(code="ac-3", verifier=verifier, redirect_uri="https://app/cb")
+    res = await client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": "ac-3",
+            "redirect_uri": "https://wrong.example/cb",
+            "code_verifier": verifier,
+        },
+    )
+    assert res.status_code == 400
+
+
+async def test_token_auth_code_is_single_use(client: httpx.AsyncClient) -> None:
+    verifier, _ = _pkce_pair()
+    _seed_auth_code(code="ac-4", verifier=verifier, redirect_uri="https://app/cb")
+    data = {
+        "grant_type": "authorization_code",
+        "code": "ac-4",
+        "redirect_uri": "https://app/cb",
+        "code_verifier": verifier,
+    }
+    r1 = await client.post("/oauth/token", data=data)
+    r2 = await client.post("/oauth/token", data=data)
+    assert r1.status_code == 200
+    assert r2.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /oauth/token (refresh_token)
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_token_rotation(client: httpx.AsyncClient) -> None:
+    verifier, _ = _pkce_pair()
+    _seed_auth_code(code="ac-5", verifier=verifier, redirect_uri="https://app/cb")
+    r1 = await client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": "ac-5",
+            "redirect_uri": "https://app/cb",
+            "code_verifier": verifier,
+        },
+    )
+    refresh_1 = r1.json()["refresh_token"]
+
+    r2 = await client.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": refresh_1},
+    )
+    assert r2.status_code == 200
+    body = r2.json()
+    refresh_2 = body["refresh_token"]
+    assert refresh_2 != refresh_1
+    claims = jwt.decode(body["access_token"], SECRET, algorithms=["HS256"])
+    assert claims["sub"] == USER_ID
+
+    # Old refresh token must now be rejected (single-use rotation).
+    r3 = await client.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": refresh_1},
+    )
+    assert r3.status_code == 400

--- a/mcp/tests/test_oauth_callback.py
+++ b/mcp/tests/test_oauth_callback.py
@@ -1,0 +1,177 @@
+"""Callback endpoint tests — Supabase token exchange + JWT decode."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import jwt
+import pytest
+
+import oauth as oauth_module
+import oauth_state
+import settings as settings_module
+from main import app
+
+SUPABASE_JWT_SECRET = "supabase-jwt-secret-needs-to-be-at-least-32-bytes"
+SUPABASE_URL = "https://supabase.test"
+USER_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        settings_module.settings, "mcp_base_url", "https://test.example.com"
+    )
+    monkeypatch.setattr(settings_module.settings, "supabase_url", SUPABASE_URL)
+    monkeypatch.setattr(settings_module.settings, "supabase_anon_key", "anon-key")
+    monkeypatch.setattr(
+        settings_module.settings, "supabase_jwt_secret", SUPABASE_JWT_SECRET
+    )
+    monkeypatch.setattr(
+        settings_module.settings,
+        "secret_key",
+        "kindred-secret-needs-to-be-at-least-32-bytes!",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_state() -> None:
+    oauth_state.oauth_sessions.clear()
+    oauth_state.auth_codes.clear()
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+def _seed_session(server_state: str, redirect_uri: str = "https://app/cb") -> None:
+    oauth_state.oauth_sessions[server_state] = {
+        "client_state": "client-st",
+        "redirect_uri": redirect_uri,
+        "code_challenge": "ch",
+        "code_challenge_method": "S256",
+        "client_id": "test-client",
+        "scope": "mcp",
+        "supabase_code_verifier": "verifier-xyz",
+        "expires_at": datetime.now(UTC) + timedelta(minutes=5),
+    }
+
+
+class _StubResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Minimal stand-in for ``httpx.AsyncClient`` used inside ``oauth.py``."""
+
+    response: _StubResponse = _StubResponse(200, {})
+
+    def __init__(self, *_args: Any, **_kw: Any) -> None: ...
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None: ...
+
+    async def post(self, *_args: Any, **_kw: Any) -> _StubResponse:
+        return type(self).response
+
+
+def _make_supabase_jwt() -> str:
+    return jwt.encode(
+        {
+            "sub": USER_ID,
+            "email": "u@example.com",
+            "aud": "authenticated",
+            "exp": int((datetime.now(UTC) + timedelta(hours=1)).timestamp()),
+        },
+        SUPABASE_JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+async def test_callback_success_redirects_with_kindred_code(
+    monkeypatch: pytest.MonkeyPatch, client: httpx.AsyncClient
+) -> None:
+    _seed_session("server-state-1", "https://app/cb")
+    supabase_jwt = _make_supabase_jwt()
+    _FakeAsyncClient.response = _StubResponse(200, {"access_token": supabase_jwt})
+    monkeypatch.setattr(oauth_module.httpx, "AsyncClient", _FakeAsyncClient)
+
+    res = await client.get(
+        "/oauth/callback",
+        params={"code": "supabase-code", "state": "server-state-1"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    parsed = urlparse(res.headers["location"])
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://app/cb"
+    qs = parse_qs(parsed.query)
+    assert "code" in qs
+    assert qs["state"] == ["client-st"]
+    # an auth code entry was minted with the right user_id
+    kindred_code = qs["code"][0]
+    assert kindred_code in oauth_state.auth_codes
+    assert oauth_state.auth_codes[kindred_code]["user_id"] == USER_ID
+
+
+async def test_callback_supabase_400_redirects_with_error(
+    monkeypatch: pytest.MonkeyPatch, client: httpx.AsyncClient
+) -> None:
+    _seed_session("server-state-2")
+    _FakeAsyncClient.response = _StubResponse(400, {"error": "invalid_grant"})
+    monkeypatch.setattr(oauth_module.httpx, "AsyncClient", _FakeAsyncClient)
+
+    res = await client.get(
+        "/oauth/callback",
+        params={"code": "x", "state": "server-state-2"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    qs = parse_qs(urlparse(res.headers["location"]).query)
+    assert qs["error"] == ["server_error"]
+
+
+async def test_callback_unknown_state_returns_400(client: httpx.AsyncClient) -> None:
+    res = await client.get(
+        "/oauth/callback",
+        params={"code": "x", "state": "never-seeded"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 400
+
+
+async def test_callback_jwt_decode_failure_redirects_with_error(
+    monkeypatch: pytest.MonkeyPatch, client: httpx.AsyncClient
+) -> None:
+    _seed_session("server-state-3")
+    # access_token signed with a *different* secret → decode will fail
+    bad_jwt = jwt.encode(
+        {"sub": USER_ID, "aud": "authenticated"},
+        "different-secret-which-is-also-32-bytes-long",
+        algorithm="HS256",
+    )
+    _FakeAsyncClient.response = _StubResponse(200, {"access_token": bad_jwt})
+    monkeypatch.setattr(oauth_module.httpx, "AsyncClient", _FakeAsyncClient)
+
+    res = await client.get(
+        "/oauth/callback",
+        params={"code": "x", "state": "server-state-3"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    qs = parse_qs(urlparse(res.headers["location"]).query)
+    assert qs["error"] == ["server_error"]

--- a/mcp/tests/test_oauth_discovery.py
+++ b/mcp/tests/test_oauth_discovery.py
@@ -1,0 +1,57 @@
+"""Discovery endpoint tests (RFC 9728 + RFC 8414)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+import settings as settings_module
+from main import app
+
+BASE = "https://test.example.com"
+
+
+@pytest.fixture(autouse=True)
+def _set_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_base_url", BASE)
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+async def test_protected_resource_metadata(client: httpx.AsyncClient) -> None:
+    res = await client.get("/.well-known/oauth-protected-resource")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["resource"] == f"{BASE}/mcp/"
+    assert data["authorization_servers"] == [BASE]
+    assert data["scopes_supported"] == ["mcp"]
+
+
+async def test_authorization_server_metadata(client: httpx.AsyncClient) -> None:
+    res = await client.get("/.well-known/oauth-authorization-server")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["issuer"] == BASE
+    assert data["authorization_endpoint"] == f"{BASE}/oauth/authorize"
+    assert data["token_endpoint"] == f"{BASE}/oauth/token"
+    assert data["registration_endpoint"] == f"{BASE}/oauth/register"
+    assert data["response_types_supported"] == ["code"]
+    assert data["grant_types_supported"] == ["authorization_code", "refresh_token"]
+    assert data["code_challenge_methods_supported"] == ["S256"]
+    assert data["scopes_supported"] == ["mcp"]
+
+
+async def test_protected_resource_metadata_501_when_base_url_unset(
+    monkeypatch: pytest.MonkeyPatch, client: httpx.AsyncClient
+) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_base_url", "")
+    res = await client.get("/.well-known/oauth-protected-resource")
+    assert res.status_code == 501

--- a/mcp/tests/test_oauth_register.py
+++ b/mcp/tests/test_oauth_register.py
@@ -1,0 +1,82 @@
+"""Dynamic Client Registration tests (RFC 7591)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+import oauth_state
+import settings as settings_module
+from main import app
+
+
+@pytest.fixture(autouse=True)
+def _set_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        settings_module.settings, "mcp_base_url", "https://test.example.com"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_state() -> None:
+    oauth_state.registered_clients.clear()
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+async def test_register_returns_201_with_credentials(client: httpx.AsyncClient) -> None:
+    res = await client.post(
+        "/oauth/register",
+        json={
+            "client_name": "claude-ai",
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+        },
+    )
+    assert res.status_code == 201
+    data = res.json()
+    assert "client_id" in data
+    assert len(data["client_id"]) == 32  # uuid4().hex
+    assert "client_secret" in data
+    assert len(data["client_secret"]) >= 32
+    assert data["client_name"] == "claude-ai"
+    assert data["redirect_uris"] == ["https://claude.ai/api/mcp/auth_callback"]
+
+
+async def test_register_persists_in_state_store(client: httpx.AsyncClient) -> None:
+    res = await client.post(
+        "/oauth/register",
+        json={"client_name": "x", "redirect_uris": ["https://example.com/cb"]},
+    )
+    assert res.status_code == 201
+    cid = res.json()["client_id"]
+    assert cid in oauth_state.registered_clients
+    assert oauth_state.registered_clients[cid]["redirect_uris"] == [
+        "https://example.com/cb"
+    ]
+
+
+async def test_register_assigns_distinct_client_ids(client: httpx.AsyncClient) -> None:
+    body = {"client_name": "same", "redirect_uris": ["https://a/cb"]}
+    r1 = await client.post("/oauth/register", json=body)
+    r2 = await client.post("/oauth/register", json=body)
+    assert r1.status_code == 201 and r2.status_code == 201
+    assert r1.json()["client_id"] != r2.json()["client_id"]
+
+
+async def test_register_supplies_defaults_for_omitted_fields(
+    client: httpx.AsyncClient,
+) -> None:
+    res = await client.post("/oauth/register", json={})
+    assert res.status_code == 201
+    data = res.json()
+    assert data["grant_types"] == ["authorization_code"]
+    assert data["response_types"] == ["code"]
+    assert data["scope"] == "mcp"

--- a/mcp/tests/test_settings.py
+++ b/mcp/tests/test_settings.py
@@ -30,3 +30,40 @@ def test_mcp_allowed_hosts_default_empty(monkeypatch: pytest.MonkeyPatch) -> Non
 
     importlib.reload(settings_module)
     assert settings_module.settings.mcp_allowed_hosts == ""
+
+
+@pytest.mark.parametrize(
+    ("env_var", "field"),
+    [
+        ("MCP_BASE_URL", "mcp_base_url"),
+        ("SECRET_KEY", "secret_key"),
+        ("SUPABASE_ANON_KEY", "supabase_anon_key"),
+        ("SUPABASE_JWT_SECRET", "supabase_jwt_secret"),
+    ],
+)
+def test_oauth_settings_round_trip(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, field: str
+) -> None:
+    monkeypatch.setenv(env_var, f"value-for-{field}")
+    import settings as settings_module
+
+    importlib.reload(settings_module)
+    assert getattr(settings_module.settings, field) == f"value-for-{field}"
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["mcp_base_url", "secret_key", "supabase_anon_key", "supabase_jwt_secret"],
+)
+def test_oauth_settings_default_empty(monkeypatch: pytest.MonkeyPatch, field: str) -> None:
+    for env_var in (
+        "MCP_BASE_URL",
+        "SECRET_KEY",
+        "SUPABASE_ANON_KEY",
+        "SUPABASE_JWT_SECRET",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    import settings as settings_module
+
+    importlib.reload(settings_module)
+    assert getattr(settings_module.settings, field) == ""


### PR DESCRIPTION
## Summary

Implements OAuth 2.1 discovery + authorization endpoints on the Kindred MCP server so Claude.ai's MCP connector can authenticate users via Supabase Google OAuth. Previously `/.well-known/oauth-protected-resource` returned 404, causing Claude.ai's auth probe to fail and tool calls to crash with `LookupError` on the `current_user_id` ContextVar.

The connector-token path (existing `ConnectorTokenVerifier` + DB lookup) is preserved unchanged for backwards compatibility.

Fixes #11

## Changes

**New endpoints (registered via `@mcp.custom_route()`):**
- `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata
- `GET /.well-known/oauth-authorization-server` — RFC 8414 metadata
- `POST /oauth/register` — RFC 7591 dynamic client registration
- `GET /oauth/authorize` — redirects to Supabase Google OAuth with server-side PKCE
- `GET /oauth/callback` — exchanges Supabase `code` via `POST /auth/v1/token?grant_type=pkce`, decodes the access-token JWT to extract `user_id`/`email`, mints our own auth code
- `POST /oauth/token` — issues HS256 JWT signed with `SECRET_KEY`; supports `authorization_code` and `refresh_token` grants with single-use rotation

**Middleware (`mcp/main.py` `with_user_context`):**
- Accepts both connector tokens (DB lookup) and server-issued JWTs (`startswith(\"eyJ\")` heuristic, JWT first then DB fallback)
- Returns proper `401 Unauthorized` with `WWW-Authenticate: Bearer realm=\"kindred\", resource_metadata=\"...\"` when neither succeeds — replaces silent passthrough that previously crashed in `tools/entries.py`
- `_PUBLIC_PATH_PREFIXES` whitelist (`/.well-known/`, `/oauth/`) bypasses auth on discovery routes

**State:**
- `mcp/oauth_state.py` — bounded in-memory dicts (`oauth_sessions`, `auth_codes`, `registered_clients`, `refresh_tokens`) with TTL eviction, `MAX_ENTRIES_PER_DICT=10_000`, thread-safe via `threading.Lock`
- No persistence — process-local, matches single-tenant deployment model

**Settings (`mcp/settings.py`):** adds `mcp_base_url`, `secret_key`, `supabase_anon_key`, `supabase_jwt_secret`. Documented in `.env.example`.

**Dependencies (`mcp/requirements.txt`):** adds `pyjwt>=2.8` and `httpx>=0.27` (httpx promoted from dev to runtime for the Supabase token exchange).

## Validation Evidence

| Check | Result |
|-------|--------|
| `cd mcp && ruff check .` | All checks passed |
| `cd mcp && mypy .` | Success: no issues found in 10 source files |
| `cd mcp && pytest -q` | **49 passed** in 1.35s (38 new + 11 existing, no regressions) |
| `cd web/backend && ruff check . && mypy . && pytest -q` | clean, 11 passed |
| `cd web/frontend && npm run lint && npm run typecheck && npm test` | clean, 1 passed |
| In-process smoke test (`/.well-known/*`, `/oauth/register`, `/mcp/`) | Discovery 200; register 201; protected `/mcp/` returns 401 with the expected `WWW-Authenticate` header |

### New tests
| File | Tests |
|------|-------|
| `mcp/tests/test_oauth_discovery.py` | 3 |
| `mcp/tests/test_oauth_register.py` | 4 |
| `mcp/tests/test_oauth_authorize_token.py` | 10 — full PKCE round-trip, validation errors, refresh-token rotation, single-use enforcement |
| `mcp/tests/test_oauth_callback.py` | 4 — Supabase token-exchange mocked via custom `httpx.AsyncClient` stub |
| `mcp/tests/test_auth.py` (extended) | +5 — JWT decode (valid/expired/wrong-secret), middleware 401 + WWW-Authenticate |
| `mcp/tests/test_settings.py` (extended) | +8 (parametrized) — round-trip for each new env var |

## Deviations from Plan

- **Public-path whitelist needed in `with_user_context`**: the plan assumed `@mcp.custom_route()` paths bypass the wrapping ASGI middleware. They don't — `mcp.streamable_http_app()` returns a Starlette app whose routes include them, and our outer middleware wraps the whole thing. Added an early `_is_public_path()` short-circuit. Caught by the in-process smoke test from Task 7.
- **`# type: ignore[untyped-decorator]`** added per registered handler in `mcp/oauth.py` — FastMCP's `custom_route` has no return annotation, and project mypy is strict.
- **`from datetime import UTC`** instead of `timezone.utc` — required by the project's ruff `UP017` rule.
- **`starlette.exceptions.HTTPException`** instead of `fastapi.HTTPException` — FastMCP's `custom_route` is built directly on Starlette; this keeps the file's imports consistent.

## Out of Scope (deliberately deferred)

- No persistent OAuth state (registered clients & refresh tokens stay in-memory; matches reli's pattern; Railway redeploys are infrequent enough)
- No `/oauth/revoke` (RFC 7009)
- No RS256/JWKS — HS256 only, mirrors `web/backend/auth.py`'s current stance
- No frontend changes; no `web/backend` changes
- No replacement of `ConnectorTokenVerifier` — backwards compat preserved per issue criterion #4

## Production Rollout (post-merge)

1. Set on Railway: `MCP_BASE_URL`, `SECRET_KEY` (e.g. `python -c \"import secrets; print(secrets.token_urlsafe(32))\"`), `SUPABASE_ANON_KEY`, `SUPABASE_JWT_SECRET`
2. Add `{MCP_BASE_URL}/oauth/callback` to Supabase Auth's redirect-URL allowlist
3. In Claude.ai → Settings → Connectors → Add MCP server → URL: `https://kindred-mcp.interstellarai.net/mcp`
4. Verify Google login popup appears; tools become callable as the authenticated user

## Test plan

- [ ] CI gates pass (`./scripts/gates.sh` equivalent)
- [ ] Railway env vars set and redeploy completes
- [ ] Supabase redirect-URL allowlist updated
- [ ] Claude.ai connector adds successfully and a `save_entry` call works end-to-end
- [ ] Existing connector-token clients continue to work (paste a connector token → tools callable)
- [ ] Unauthenticated `/mcp/` request returns 401 with `WWW-Authenticate` (not a 500)