### PR TITLE
Fix gates CI: align oauth-protected-resource test with prod /mcp value

### DIFF
--- a/mcp/tests/test_oauth_discovery.py
+++ b/mcp/tests/test_oauth_discovery.py
@@ -30,9 +30,10 @@ async def test_protected_resource_metadata(client: httpx.AsyncClient) -> None:
     res = await client.get("/.well-known/oauth-protected-resource")
     assert res.status_code == 200
     data = res.json()
-    assert data["resource"] == f"{BASE}/mcp/"
+    assert data["resource"] == f"{BASE}/mcp"
     assert data["authorization_servers"] == [BASE]
     assert data["scopes_supported"] == ["mcp"]
+    assert data["bearer_methods_supported"] == ["header"]
 
 
 async def test_authorization_server_metadata(client: httpx.AsyncClient) -> None:
@@ -46,6 +47,7 @@ async def test_authorization_server_metadata(client: httpx.AsyncClient) -> None:
     assert data["response_types_supported"] == ["code"]
     assert data["grant_types_supported"] == ["authorization_code", "refresh_token"]
     assert data["code_challenge_methods_supported"] == ["S256"]
+    assert data["token_endpoint_auth_methods_supported"] == ["none"]
     assert data["scopes_supported"] == ["mcp"]
 
 


### PR DESCRIPTION
## Summary

Main CI's `gates` job was red because `tests/test_oauth_discovery.py::test_protected_resource_metadata` asserted the `resource` field was `f"{BASE}/mcp/"` (trailing slash), but commit `dd78a3c` intentionally changed the production response to `f"{BASE}/mcp"` (no trailing slash) per RFC 8707 / Claude.ai expectations. The prod change was correct; the test simply wasn't updated alongside it.

This PR updates the test to match prod and locks in the two new metadata fields introduced in the same commit so future drift is caught.

Fixes #15

## Changes

- `mcp/tests/test_oauth_discovery.py`
  - Drop trailing slash on the `resource` assertion in `test_protected_resource_metadata` (`/mcp/` → `/mcp`)
  - Add assertion for `bearer_methods_supported == ["header"]` (new field in `dd78a3c`)
  - Add assertion for `token_endpoint_auth_methods_supported == ["none"]` in `test_authorization_server_metadata` (new field in `dd78a3c`)

No production code change. Scope was deliberately limited to `mcp/tests/` per the investigation — `mcp/oauth.py` is correct as-is.

## Root cause

Commit `dd78a3c` ("fix(oauth): add flow_type=pkce, fix resource URL trailing slash, add auth method hint") updated `mcp/oauth.py:145` to drop the trailing slash but did not update the matching test assertion at `mcp/tests/test_oauth_discovery.py:33`. Last green run before the regression: 25248145364 (commit `28c857a`).

## Validation

Run from `mcp/` using a project-local venv (system pip is PEP 668 externally-managed):

| Check | Command | Result |
|-------|---------|--------|
| Lint | `ruff check .` | PASS — All checks passed |
| Typecheck | `mypy .` | PASS — Success: no issues found in 10 source files |
| Targeted tests | `pytest tests/test_oauth_discovery.py -v` | PASS — 3 passed |
| Full mcp suite | `pytest -q` | PASS — 49 passed in 1.29s |

The previously-failing `test_protected_resource_metadata` now passes alongside the two new assertions. `web/backend` and `web/frontend` gates were intentionally not run locally — they were not in the failure trace and are untouched by this change; CI will cover them on push.

## Test plan

- [ ] CI `gates` job goes green on this PR
- [ ] `mcp` lint, typecheck, and pytest all pass in CI
- [ ] No regressions in `web/backend` or `web/frontend` gates