### PR TITLE
fix(mcp): wrap long dict literal in oauth.py to satisfy ruff E501

### DIFF
--- a/mcp/oauth.py
+++ b/mcp/oauth.py
@@ -295,7 +295,10 @@ def register_routes(mcp_obj: FastMCP) -> None:
 
         if not flow_id or not access_token:
             return JSONResponse(
-                {"error": "invalid_request", "error_description": "flow_id and access_token required"},
+                {
+                    "error": "invalid_request",
+                    "error_description": "flow_id and access_token required",
+                },
                 status_code=400,
                 headers=_CORS_HEADERS,
             )


### PR DESCRIPTION
## Summary

Fixes the `gates` job on `main` (CI red since commit `63a2eb1`). `ruff check .` in `mcp/` reported a single E501 violation at `mcp/oauth.py:298` (103 > 100 cols). This PR wraps that one offending dict literal across multiple lines so the file passes lint.

Fixes #17

## Root cause

The dict literal on `mcp/oauth.py:298` is 103 chars — 3 over the project's `line-length = 100` (`mcp/pyproject.toml`). Introduced in `91a0242` ("feat(oauth): relay Google OAuth through web-app…") which added a longer `error_description` message. `gates.sh` runs under `set -euo pipefail`, so the lint failure halts the entire pipeline.

## Changes

- `mcp/oauth.py` (+4/-1): wrap the `flow_id and access_token required` `JSONResponse` dict across multiple lines (standard ruff-format / black style). Response body is byte-for-byte identical.

The other 4 `error_description` lines in this file (288, 306, 321, 330) already fit in 100 cols and were deliberately left untouched (no churn).

## Validation

| Check | Result |
|-------|--------|
| `cd mcp && ruff check .` | PASS — "All checks passed!" |
| `cd mcp && mypy .` | PASS — "Success: no issues found in 10 source files" |
| `cd mcp && pytest -q` | 44 passed, **5 pre-existing failures** (out of scope — see below) |

Max line length verification (`awk '{print length($0), NR}' mcp/oauth.py | sort -rn | head -5`): top non-ignored line is now 97 chars.

## Out-of-scope finding: pre-existing test failures

After this lint fix lands, `gates.sh` will progress past lint and surface 5 pre-existing pytest failures in `mcp/`:

```
FAILED tests/test_oauth_authorize_token.py::test_authorize_redirects_to_supabase
FAILED tests/test_oauth_callback.py::test_callback_success_redirects_with_kindred_code
FAILED tests/test_oauth_callback.py::test_callback_supabase_400_redirects_with_error
FAILED tests/test_oauth_callback.py::test_callback_unknown_state_returns_400
FAILED tests/test_oauth_callback.py::test_callback_jwt_decode_failure_redirects_with_error
```

All five fail with `AttributeError: module 'oauth' has no attribute 'httpx'`. The tests `monkeypatch.setattr(oauth_module.httpx, "AsyncClient", …)`, but `mcp/oauth.py` no longer imports `httpx` — that import was removed in `91a0242` when the OAuth flow was refactored to relay through the web-app.

**Confirmed pre-existing**: reproduced on unmodified `63a2eb1` HEAD via `git stash && pytest -q`. They were masked in CI by `set -euo pipefail` halting at the first ruff error.

**Not fixed here** because the investigation explicitly listed "rework of `oauth.py` logic, the Supabase OAuth relay flow" as out of scope. Recommend a separate issue to either (a) update the tests to monkeypatch the new web-app relay code path, or (b) delete the obsolete tests.

## Test plan

- [ ] CI `gates` job goes green on this branch
- [ ] `mcp/oauth.py:297-304` reads as a clean multi-line dict literal
- [ ] No behavioral change to the `oauth_code_from_session` 400 response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)