### PR TITLE
feat(web): implement Kindred design system

### DIFF
--- a/web/frontend/public/illustration-orbit.svg
+++ b/web/frontend/public/illustration-orbit.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" fill="none">
+  
+  <defs>
+    <pattern id="dots" x="0" y="0" width="8" height="8" patternUnits="userSpaceOnUse">
+      <circle cx="1" cy="1" r="0.8" fill="#8B7355" opacity="0.3"></circle>
+    </pattern>
+  </defs>
+  <rect width="400" height="400" fill="url(#dots)"></rect>
+  <circle cx="200" cy="200" r="180" stroke="#1A1A1A" stroke-width="1" fill="none" opacity="0.15"></circle>
+  <circle cx="200" cy="200" r="130" stroke="#1A1A1A" stroke-width="1" fill="none" opacity="0.25" stroke-dasharray="2 4"></circle>
+  <ellipse cx="200" cy="200" rx="160" ry="60" transform="rotate(-18 200 200)" stroke="#1A1A1A" stroke-width="1.5" fill="none"></ellipse>
+  <ellipse cx="200" cy="200" rx="100" ry="40" transform="rotate(18 200 200)" stroke="#D97757" stroke-width="1.5" fill="none"></ellipse>
+  <circle cx="200" cy="200" r="18" fill="#D97757"></circle>
+  <circle cx="200" cy="200" r="8" fill="#FAF7F2"></circle>
+  
+  <circle cx="348" cy="152" r="5" fill="#1A1A1A"></circle>
+  <circle cx="52" cy="248" r="4" fill="#2B3A67"></circle>
+  <circle cx="260" cy="70" r="3" fill="#1A1A1A"></circle>
+  <circle cx="110" cy="340" r="3" fill="#E8A33D"></circle>
+</svg>

--- a/web/frontend/public/illustration-plaque.svg
+++ b/web/frontend/public/illustration-plaque.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" fill="none">
+  
+  <rect width="400" height="400" fill="#F3EFE6"></rect>
+  <g stroke="#1A1A1A" stroke-width="1.5" fill="none">
+    
+    <circle cx="200" cy="200" r="40" fill="#D97757" stroke="none"></circle>
+    <g stroke="#1A1A1A">
+      <line x1="200" y1="80" x2="200" y2="130"></line>
+      <line x1="200" y1="270" x2="200" y2="320"></line>
+      <line x1="80" y1="200" x2="130" y2="200"></line>
+      <line x1="270" y1="200" x2="320" y2="200"></line>
+      <line x1="115" y1="115" x2="150" y2="150"></line>
+      <line x1="250" y1="250" x2="285" y2="285"></line>
+      <line x1="115" y1="285" x2="150" y2="250"></line>
+      <line x1="250" y1="150" x2="285" y2="115"></line>
+    </g>
+    
+    <rect x="30" y="30" width="340" height="340" rx="8"></rect>
+  </g>
+  
+  <g fill="#1A1A1A">
+    <rect x="60" y="60" width="8" height="2"></rect>
+    <rect x="72" y="60" width="4" height="2"></rect>
+    <rect x="80" y="60" width="10" height="2"></rect>
+    <rect x="332" y="338" width="8" height="2"></rect>
+    <rect x="322" y="338" width="4" height="2"></rect>
+    <rect x="310" y="338" width="10" height="2"></rect>
+  </g>
+</svg>

--- a/web/frontend/public/logo-mark.svg
+++ b/web/frontend/public/logo-mark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  
+  <ellipse cx="32" cy="32" rx="26" ry="10" transform="rotate(-24 32 32)" stroke="#1A1A1A" stroke-width="2.5" fill="none"></ellipse>
+  <circle cx="32" cy="32" r="6" fill="#D97757"></circle>
+  <circle cx="52" cy="22" r="2.5" fill="#1A1A1A"></circle>
+</svg>

--- a/web/frontend/public/texture-stars.svg
+++ b/web/frontend/public/texture-stars.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200" fill="none">
+  <rect width="400" height="200" fill="#FAF7F2"></rect>
+  
+  <g fill="#1A1A1A">
+    <circle cx="30" cy="40" r="1"></circle>
+    <circle cx="80" cy="60" r="0.8"></circle>
+    <circle cx="130" cy="30" r="1.2"></circle>
+    <circle cx="180" cy="70" r="0.8"></circle>
+    <circle cx="230" cy="45" r="1"></circle>
+    <circle cx="280" cy="25" r="0.9"></circle>
+    <circle cx="330" cy="60" r="1.1"></circle>
+    <circle cx="370" cy="40" r="0.8"></circle>
+    <circle cx="50" cy="120" r="0.8"></circle>
+    <circle cx="100" cy="150" r="1"></circle>
+    <circle cx="160" cy="130" r="0.9"></circle>
+    <circle cx="220" cy="160" r="1.1"></circle>
+    <circle cx="290" cy="140" r="0.8"></circle>
+    <circle cx="340" cy="170" r="1"></circle>
+    <circle cx="380" cy="120" r="0.9"></circle>
+  </g>
+  
+  <g stroke="#8B7355" stroke-width="0.5" opacity="0.6">
+    <line x1="80" y1="60" x2="130" y2="30"></line>
+    <line x1="130" y1="30" x2="180" y2="70"></line>
+    <line x1="180" y1="70" x2="230" y2="45"></line>
+    <line x1="100" y1="150" x2="160" y2="130"></line>
+    <line x1="160" y1="130" x2="220" y2="160"></line>
+  </g>
+</svg>

--- a/web/frontend/src/components/Brand.tsx
+++ b/web/frontend/src/components/Brand.tsx
@@ -1,0 +1,39 @@
+type KindredMarkProps = {
+  size?: number
+  accent?: string
+  ink?: string
+}
+
+export function KindredMark({ size = 28, accent = '#7C7AB5', ink = '#1A1A1A' }: KindredMarkProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 64 64" fill="none" aria-hidden="true">
+      {/* outer dashed orbit, faint */}
+      <ellipse
+        cx="32" cy="32" rx="28" ry="11"
+        transform="rotate(-22 32 32)"
+        stroke={ink} strokeOpacity="0.18" strokeWidth="1" strokeDasharray="2 4" fill="none"
+      />
+      {/* two interlocking rings */}
+      <circle cx="24" cy="32" r="11" stroke={ink} strokeWidth="2" fill="none" />
+      <circle cx="40" cy="32" r="11" stroke={accent} strokeWidth="2" fill="none" />
+      {/* the meeting point */}
+      <circle cx="32" cy="32" r="2" fill={accent} />
+    </svg>
+  )
+}
+
+type KindredWordmarkProps = {
+  inverse?: boolean
+}
+
+export function KindredWordmark({ inverse = false }: KindredWordmarkProps) {
+  const ink = inverse ? '#FAF7F2' : '#1A1A1A'
+  return (
+    <div className="nav-brand" style={{ color: ink }}>
+      <KindredMark size={28} ink={ink} />
+      <span className="wm">
+        <em>Kindred</em><span className="dot">.</span>
+      </span>
+    </div>
+  )
+}

--- a/web/frontend/src/components/Layout.tsx
+++ b/web/frontend/src/components/Layout.tsx
@@ -1,42 +1,166 @@
-import { Link, Navigate, Outlet, useLocation } from 'react-router'
+import { Link, Navigate, Outlet, useLocation, useNavigate } from 'react-router'
 import { useAuth } from '../store/auth'
 import { supabase } from '../lib/supabase'
+import { KindredMark } from './Brand'
+
+type IconName = 'book' | 'layers' | 'search' | 'settings' | 'plug'
+
+function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
+  const paths: Record<IconName, React.ReactNode> = {
+    book: (
+      <>
+        <path d="M4 4v16a2 2 0 0 0 2 2h14" />
+        <path d="M4 4h14v18" />
+        <path d="M8 8h6M8 12h6M8 16h4" />
+      </>
+    ),
+    layers: (
+      <>
+        <path d="M12 2L2 8l10 6 10-6-10-6z" />
+        <path d="M2 14l10 6 10-6" />
+      </>
+    ),
+    search: (
+      <>
+        <circle cx="11" cy="11" r="7" />
+        <path d="M21 21l-5-5" />
+      </>
+    ),
+    settings: (
+      <>
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
+      </>
+    ),
+    plug: (
+      <>
+        <path d="M9 2v6" />
+        <path d="M15 2v6" />
+        <path d="M5 8h14v3a7 7 0 0 1-14 0z" />
+        <path d="M12 18v4" />
+      </>
+    ),
+  }
+  return (
+    <svg
+      className="ico"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {paths[name]}
+    </svg>
+  )
+}
 
 export function Layout() {
   const session = useAuth((s) => s.session)
   const location = useLocation()
+  const navigate = useNavigate()
 
-  if (!session && location.pathname !== '/login') {
+  if (!session) {
     return <Navigate to="/login" replace />
   }
 
-  if (location.pathname === '/login') {
-    return <Outlet />
+  const email = session?.user?.email ?? ''
+  const name = email.split('@')[0] ?? 'User'
+  const initial = (name[0] ?? '?').toUpperCase()
+
+  const isActive = (path: string) => {
+    if (path === '/app') return location.pathname === '/app'
+    return location.pathname.startsWith(path)
   }
 
+  const libraryItems: { path: string; label: string; icon: IconName }[] = [
+    { path: '/app', label: 'Entries', icon: 'book' },
+    { path: '/app/patterns', label: 'Patterns', icon: 'layers' },
+    { path: '/app/search', label: 'Search', icon: 'search' },
+  ]
+
+  const accountItems: { path: string; label: string; icon: IconName }[] = [
+    { path: '/app/connect', label: 'Connect to Claude', icon: 'plug' },
+    { path: '/app/settings', label: 'Settings', icon: 'settings' },
+  ]
+
   return (
-    <div className="min-h-screen bg-stone-50 text-stone-900">
-      <nav className="border-b border-stone-200 bg-white">
-        <div className="mx-auto flex max-w-3xl items-center gap-6 px-6 py-4 text-sm">
-          <Link to="/" className="font-semibold">
-            Kindred
-          </Link>
-          <Link to="/patterns">Patterns</Link>
-          <Link to="/search">Search</Link>
-          <Link to="/connect">Connect</Link>
-          <Link to="/settings" className="ml-auto">
-            Settings
-          </Link>
+    <div className="app">
+      <aside className="side">
+        <Link to="/app" className="side-brand">
+          <KindredMark size={26} />
+          <span className="wm">
+            <em>Kindred</em>
+            <span className="dot">.</span>
+          </span>
+        </Link>
+
+        <div className="side-search" onClick={() => void navigate('/app/search')} style={{ cursor: 'pointer' }}>
+          <Icon name="search" size={14} />
+          <input placeholder="Search by feeling, theme…" readOnly />
+          <span className="kbd">⌘K</span>
+        </div>
+
+        <div className="side-eye">Library</div>
+        <nav className="side-nav">
+          {libraryItems.map((item) => (
+            <Link
+              key={item.path}
+              to={item.path}
+              className={`side-link ${isActive(item.path) ? 'is-active' : ''}`}
+            >
+              <Icon name={item.icon} />
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </nav>
+
+        <div className="side-eye">Account</div>
+        <nav className="side-nav">
+          {accountItems.map((item) => (
+            <Link
+              key={item.path}
+              to={item.path}
+              className={`side-link ${isActive(item.path) ? 'is-active' : ''}`}
+            >
+              <Icon name={item.icon} />
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </nav>
+
+        <div className="side-foot">
+          <div className="side-avatar">{initial}</div>
+          <div className="who">
+            {name}
+            <small>{email}</small>
+          </div>
           <button
             type="button"
             onClick={() => void supabase.auth.signOut()}
-            className="text-stone-500 hover:text-stone-900"
+            style={{
+              marginLeft: 'auto',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-mono)',
+              fontSize: '10px',
+              color: 'var(--ink-3)',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              padding: '4px',
+            }}
+            title="Sign out"
           >
-            Sign out
+            ↩
           </button>
         </div>
-      </nav>
-      <main className="mx-auto max-w-3xl px-6 py-8">
+      </aside>
+
+      <main className="main">
         <Outlet />
       </main>
     </div>

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -1,1 +1,888 @@
+@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
 @import "tailwindcss";
+
+/* ============================================================
+   InterstellarAI — colors_and_type.css
+   Core design tokens: color, type, spacing, radius, shadow.
+   ============================================================ */
+
+:root {
+  /* -------- PAPER / NEUTRALS (warm, slightly cream) -------- */
+  --paper:        #FAF7F2;   /* default page bg */
+  --paper-2:      #F3EFE6;   /* slightly recessed card / rail */
+  --paper-3:      #E8E2D4;   /* dividers, keyboard keys */
+  --ink:          #1A1A1A;   /* body text */
+  --ink-2:        #3A3A3A;   /* secondary text */
+  --ink-3:        #8B7355;   /* tertiary, warm gray-brown */
+  --ink-4:        #B8AD9A;   /* quaternary, muted */
+
+  /* -------- BRAND ACCENTS -------- */
+  --terracotta:   #D97757;   /* primary brand accent, CTA */
+  --terracotta-2: #C15D3D;   /* pressed / deeper */
+  --terracotta-3: #F2C7B5;   /* tint, highlight backgrounds */
+  --slate:        #2B3A67;   /* deep blue-black, ink alt */
+  --slate-2:      #4A5B8C;   /* secondary slate */
+  --dusk:         #7A8B99;   /* cool gray for UI chrome */
+
+  /* -------- ACCENTS (used sparingly) -------- */
+  --marigold:     #E8A33D;   /* highlight, "new" badges */
+  --moss:         #6B8E5A;   /* success, positive */
+  --rust:         #B04A2F;   /* error, destructive */
+
+  /* -------- SEMANTIC -------- */
+  --bg:           var(--paper);
+  --bg-elevated:  #FFFFFF;
+  --bg-recessed:  var(--paper-2);
+  --fg:           var(--ink);
+  --fg-muted:     var(--ink-2);
+  --fg-subtle:    var(--ink-3);
+  --fg-faint:     var(--ink-4);
+  --border:       var(--paper-3);
+  --border-strong:#CFC6B2;
+  --accent:       var(--terracotta);
+  --accent-hover: var(--terracotta-2);
+  --link:         var(--slate);
+
+  /* -------- TYPE FAMILIES -------- */
+  --font-display: 'Instrument Serif', 'Georgia', serif;
+  --font-body:    'Geist', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, 'Menlo', monospace;
+
+  /* -------- TYPE SCALE -------- */
+  /* Display (serif, italic-friendly) */
+  --fs-hero:      clamp(3.5rem, 8vw, 6.5rem);   /* 56–104 */
+  --fs-display:   clamp(2.5rem, 5vw, 4rem);     /* 40–64  */
+  --fs-h1:        2.5rem;   /* 40 */
+  --fs-h2:        2rem;     /* 32 */
+  --fs-h3:        1.5rem;   /* 24 */
+  --fs-h4:        1.25rem;  /* 20 */
+
+  /* Body */
+  --fs-lg:        1.125rem; /* 18 */
+  --fs-md:        1rem;     /* 16 */
+  --fs-sm:        0.875rem; /* 14 */
+  --fs-xs:        0.75rem;  /* 12 */
+
+  /* Line heights */
+  --lh-tight:     1.05;
+  --lh-snug:      1.2;
+  --lh-normal:    1.5;
+  --lh-loose:     1.7;
+
+  /* Letter spacing */
+  --tr-tight:     -0.02em;
+  --tr-normal:    0;
+  --tr-wide:      0.04em;
+  --tr-mono:      0.02em;
+
+  /* Weights */
+  --fw-light:     300;
+  --fw-regular:   400;
+  --fw-medium:    500;
+  --fw-semibold:  600;
+  --fw-bold:      700;
+
+  /* -------- SPACING (4px base) -------- */
+  --sp-1:  0.25rem;  /*  4 */
+  --sp-2:  0.5rem;   /*  8 */
+  --sp-3:  0.75rem;  /* 12 */
+  --sp-4:  1rem;     /* 16 */
+  --sp-5:  1.5rem;   /* 24 */
+  --sp-6:  2rem;     /* 32 */
+  --sp-7:  3rem;     /* 48 */
+  --sp-8:  4rem;     /* 64 */
+  --sp-9:  6rem;     /* 96 */
+  --sp-10: 8rem;     /* 128 */
+
+  /* -------- RADII -------- */
+  --r-xs:  4px;
+  --r-sm:  8px;
+  --r-md:  12px;
+  --r-lg:  16px;
+  --r-xl:  24px;
+  --r-2xl: 32px;
+  --r-pill: 999px;
+
+  /* -------- SHADOWS (soft, warm) -------- */
+  --shadow-xs:   0 1px 2px rgba(60, 40, 20, 0.06);
+  --shadow-sm:   0 2px 8px rgba(60, 40, 20, 0.08);
+  --shadow-md:   0 8px 24px rgba(60, 40, 20, 0.10);
+  --shadow-lg:   0 16px 48px rgba(60, 40, 20, 0.14);
+  --shadow-inset:inset 0 1px 2px rgba(60, 40, 20, 0.08);
+
+  /* -------- MOTION -------- */
+  --ease-out:    cubic-bezier(0.2, 0.7, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-in-out: cubic-bezier(0.6, 0, 0.4, 1);
+  --dur-fast:    120ms;
+  --dur-med:     220ms;
+  --dur-slow:    420ms;
+}
+
+/* ============================================================
+   Base type — apply to elements by default
+   ============================================================ */
+
+html, body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-size: var(--fs-md);
+  line-height: var(--lh-normal);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4 { font-family: var(--font-display); font-weight: var(--fw-regular); letter-spacing: var(--tr-tight); line-height: var(--lh-snug); color: var(--fg); }
+h1 { font-size: var(--fs-h1); line-height: var(--lh-tight); }
+h2 { font-size: var(--fs-h2); }
+h3 { font-size: var(--fs-h3); }
+h4 { font-size: var(--fs-h4); font-family: var(--font-body); font-weight: var(--fw-semibold); letter-spacing: var(--tr-normal); }
+
+.display { font-family: var(--font-display); font-size: var(--fs-display); line-height: var(--lh-tight); letter-spacing: var(--tr-tight); }
+.hero    { font-family: var(--font-display); font-size: var(--fs-hero);    line-height: var(--lh-tight); letter-spacing: var(--tr-tight); }
+.italic  { font-style: italic; }
+
+p { margin: 0 0 var(--sp-4) 0; }
+.lede { font-size: var(--fs-lg); color: var(--fg-muted); line-height: var(--lh-loose); }
+
+small, .caption { font-size: var(--fs-sm); color: var(--fg-muted); }
+.eyebrow { font-family: var(--font-mono); font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: var(--tr-wide); color: var(--fg-subtle); }
+.mono    { font-family: var(--font-mono); font-size: 0.95em; letter-spacing: var(--tr-mono); }
+code     { font-family: var(--font-mono); font-size: 0.9em; background: var(--paper-2); padding: 2px 6px; border-radius: var(--r-xs); }
+
+a { color: var(--link); text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; transition: color var(--dur-fast) var(--ease-out); }
+a:hover { color: var(--terracotta); }
+
+hr { border: 0; border-top: 1px solid var(--border); margin: var(--sp-6) 0; }
+
+/* Selection */
+::selection { background: var(--terracotta-3); color: var(--ink); }
+
+/* ============================================================
+   app.css — App shell + all page component styles
+   ============================================================ */
+
+/* Inherit the recolored palette */
+:root {
+  --terracotta:    #7C7AB5;
+  --terracotta-2:  #5F5D96;
+  --terracotta-3:  #DEDCEF;
+  --slate:         #4A3D5C;
+  --slate-2:       #6B5C7E;
+  --moss:          #8DA88A;
+  --marigold:      #D4A574;
+  --accent:        var(--terracotta);
+  --link:          var(--slate);
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; background: var(--paper); color: var(--ink); font-family: var(--font-body); -webkit-font-smoothing: antialiased; }
+a { color: var(--slate); text-decoration: none; }
+a:hover { color: var(--terracotta); }
+button { font-family: inherit; }
+
+/* ============================================================
+   App shell — sidebar + main
+   ============================================================ */
+.app {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+}
+
+.side {
+  background: var(--paper-2);
+  border-right: 1px solid var(--border);
+  padding: var(--sp-5) var(--sp-4);
+  display: flex; flex-direction: column;
+  position: sticky; top: 0; height: 100vh;
+}
+.side-brand { display: flex; align-items: center; gap: 10px; padding: 6px 8px var(--sp-5); text-decoration: none; color: var(--ink); }
+.side-brand .wm { font-family: var(--font-display); font-size: 22px; line-height: 1; letter-spacing: -0.01em; }
+.side-brand .wm em { font-style: italic; }
+.side-brand .wm .dot { color: var(--terracotta); }
+
+.side-search {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--paper); border: 1px solid var(--border);
+  border-radius: var(--r-md); padding: 8px 10px;
+  margin-bottom: var(--sp-4);
+}
+.side-search input {
+  flex: 1; background: transparent; border: none; outline: none;
+  font-family: var(--font-body); font-size: 13.5px; color: var(--ink);
+}
+.side-search input::placeholder { color: var(--ink-4); }
+.side-search .kbd {
+  font-family: var(--font-mono); font-size: 10px; color: var(--ink-3);
+  background: var(--paper-2); border: 1px solid var(--border);
+  padding: 2px 6px; border-radius: 4px;
+}
+
+.side-nav { display: flex; flex-direction: column; gap: 2px; }
+.side-eye { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.12em; text-transform: uppercase; padding: var(--sp-3) 8px var(--sp-2); }
+.side-link {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px; border-radius: var(--r-sm);
+  font-size: 14px; color: var(--ink-2); cursor: pointer;
+  transition: all 120ms var(--ease-out); border: none; background: transparent;
+  text-align: left; width: 100%;
+}
+.side-link:hover { background: rgba(124,122,181,0.08); color: var(--ink); }
+.side-link.is-active { background: var(--bg-elevated); color: var(--ink); box-shadow: var(--shadow-xs); border: 1px solid var(--border); }
+.side-link .ico { width: 16px; height: 16px; color: var(--ink-3); flex: none; }
+.side-link.is-active .ico { color: var(--terracotta); }
+.side-link .count { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); background: var(--paper-3); padding: 1px 6px; border-radius: var(--r-pill); }
+.side-link.is-active .count { background: var(--terracotta-3); color: var(--terracotta-2); }
+
+.side-foot { margin-top: auto; padding-top: var(--sp-4); border-top: 1px solid var(--border); display: flex; align-items: center; gap: 10px; }
+.side-avatar { width: 32px; height: 32px; border-radius: 50%; background: var(--terracotta); color: var(--paper); display: grid; place-items: center; font-family: var(--font-mono); font-size: 12px; font-weight: 600; }
+.side-foot .who { font-size: 13px; color: var(--ink); line-height: 1.2; }
+.side-foot .who small { display: block; color: var(--ink-3); font-size: 11px; }
+
+/* ============================================================
+   Main area
+   ============================================================ */
+.main { padding: var(--sp-6) var(--sp-7); max-width: 960px; }
+
+.page-head { margin-bottom: var(--sp-6); }
+.page-eye { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: var(--sp-2); }
+.page-eye .glyph { color: var(--terracotta); margin-right: 6px; }
+.page-title { font-family: var(--font-display); font-size: clamp(2rem, 3.5vw, 2.8rem); line-height: 1.05; letter-spacing: -0.02em; margin: 0; font-weight: 400; }
+.page-title em { font-style: italic; color: var(--terracotta); }
+.page-sub { color: var(--ink-2); font-size: 16px; line-height: 1.55; margin: 8px 0 0; max-width: 60ch; text-wrap: pretty; }
+
+/* read-only banner */
+.readonly-banner {
+  display: flex; align-items: center; gap: 10px;
+  background: var(--paper-2);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--terracotta);
+  border-radius: var(--r-md);
+  padding: 10px 14px;
+  font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3);
+  letter-spacing: 0.04em;
+  margin-bottom: var(--sp-5);
+}
+.readonly-banner .lock { color: var(--terracotta); }
+.readonly-banner strong { color: var(--ink-2); font-weight: 500; }
+
+/* ============================================================
+   Entries list
+   ============================================================ */
+.entry-row {
+  display: grid;
+  grid-template-columns: 92px 1fr auto;
+  gap: var(--sp-5);
+  padding: var(--sp-5) 0;
+  border-top: 1px solid var(--border);
+  cursor: pointer;
+  transition: all 120ms var(--ease-out);
+  align-items: start;
+}
+.entry-row:hover { background: rgba(124,122,181,0.04); padding-left: 8px; padding-right: 8px; margin-left: -8px; margin-right: -8px; border-radius: var(--r-sm); }
+.entry-row:last-child { border-bottom: 1px solid var(--border); }
+.entry-date { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; line-height: 1.4; padding-top: 4px; }
+.entry-date .day { display: block; font-family: var(--font-display); font-size: 28px; font-style: italic; color: var(--ink); letter-spacing: -0.01em; margin-bottom: 2px; line-height: 1; }
+.entry-body h3 { font-family: var(--font-display); font-size: 22px; line-height: 1.25; margin: 0 0 6px; font-weight: 400; font-style: italic; letter-spacing: -0.01em; }
+.entry-body p { margin: 0; color: var(--ink-2); font-size: 15px; line-height: 1.55; max-width: 62ch; text-wrap: pretty; }
+.entry-tags { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
+.entry-meta { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.06em; text-align: right; padding-top: 6px; line-height: 1.6; white-space: nowrap; }
+.entry-meta .mood { color: var(--terracotta); display: block; font-size: 11px; }
+
+.tag-pill { font-family: var(--font-mono); font-size: 10px; padding: 3px 8px; border-radius: var(--r-pill); background: var(--paper-2); color: var(--ink-3); border: 1px solid var(--border); text-transform: uppercase; letter-spacing: 0.06em; cursor: pointer; }
+.tag-pill:hover { background: var(--terracotta-3); color: var(--terracotta-2); border-color: var(--terracotta-3); }
+.tag-pill.is-active { background: var(--terracotta-3); color: var(--terracotta-2); border-color: var(--terracotta-3); }
+
+/* month divider */
+.month-div { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.14em; text-transform: uppercase; margin: var(--sp-7) 0 var(--sp-2); display: flex; align-items: center; gap: 12px; }
+.month-div::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+.month-div:first-of-type { margin-top: 0; }
+
+/* ============================================================
+   Entry detail
+   ============================================================ */
+.back-link { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: var(--sp-4); cursor: pointer; background: none; border: none; padding: 0; }
+.back-link:hover { color: var(--terracotta); }
+
+.entry-detail-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: var(--sp-5);
+  padding-bottom: var(--sp-5); margin-bottom: var(--sp-5);
+  border-bottom: 1px solid var(--border);
+}
+.entry-detail-date { font-family: var(--font-display); font-size: 36px; font-style: italic; line-height: 1; letter-spacing: -0.01em; }
+.entry-detail-meta { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; text-align: right; }
+.entry-detail-meta .mood-big { color: var(--terracotta); font-size: 13px; display: block; margin-bottom: 4px; }
+
+.entry-summary {
+  font-family: var(--font-display); font-style: italic;
+  font-size: 22px; line-height: 1.45; color: var(--ink);
+  max-width: 56ch; margin: 0 0 var(--sp-7);
+  text-wrap: pretty;
+}
+.entry-summary::first-letter { font-size: 1.4em; }
+
+.entry-section-eye { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: var(--sp-3); }
+.occ-card {
+  background: var(--paper-2); border: 1px solid var(--border);
+  border-radius: var(--r-md); padding: var(--sp-4);
+  margin-bottom: var(--sp-3);
+}
+.occ-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--sp-3); }
+.occ-name { font-family: var(--font-display); font-style: italic; font-size: 18px; color: var(--ink); }
+.occ-name .glyph { color: var(--terracotta); margin-right: 6px; }
+.occ-intensity { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; }
+.occ-quads { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 24px; }
+.occ-quad { font-size: 13px; line-height: 1.5; color: var(--ink-2); }
+.occ-quad-label { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.1em; text-transform: uppercase; display: block; margin-bottom: 2px; }
+
+/* transcript */
+.transcript-wrap {
+  margin-top: var(--sp-7);
+  border-top: 1px solid var(--border);
+  padding-top: var(--sp-5);
+}
+.transcript-toggle {
+  display: flex; align-items: center; gap: 10px;
+  background: none; border: none; cursor: pointer;
+  font-family: var(--font-mono); font-size: 11px; color: var(--ink-2);
+  letter-spacing: 0.1em; text-transform: uppercase; padding: 0;
+}
+.transcript-toggle .chev { transition: transform 220ms var(--ease-out); }
+.transcript-toggle.is-open .chev { transform: rotate(90deg); }
+.transcript-body { margin-top: var(--sp-4); display: flex; flex-direction: column; gap: var(--sp-3); }
+.t-msg { display: flex; gap: 12px; max-width: 72ch; }
+.t-msg .who { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.1em; text-transform: uppercase; flex: none; width: 60px; padding-top: 4px; }
+.t-msg.kindred .who { color: var(--terracotta); }
+.t-msg .text { font-size: 14.5px; line-height: 1.55; color: var(--ink-2); }
+
+/* ============================================================
+   Patterns list
+   ============================================================ */
+.pat-list { display: flex; flex-direction: column; }
+.pat-card {
+  display: grid; grid-template-columns: 1fr auto;
+  align-items: center; gap: var(--sp-5);
+  padding: var(--sp-5) 0;
+  border-top: 1px solid var(--border);
+  cursor: pointer; transition: all 120ms var(--ease-out);
+}
+.pat-card:hover { background: rgba(124,122,181,0.04); padding-left: 8px; padding-right: 8px; margin-left: -8px; margin-right: -8px; border-radius: var(--r-sm); }
+.pat-card:last-child { border-bottom: 1px solid var(--border); }
+.pat-card-name { font-family: var(--font-display); font-style: italic; font-size: 26px; line-height: 1.2; margin: 0 0 4px; font-weight: 400; letter-spacing: -0.01em; }
+.pat-card-desc { color: var(--ink-2); font-size: 14.5px; line-height: 1.5; margin: 0; max-width: 60ch; }
+.pat-card-stats { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; text-align: right; line-height: 1.6; white-space: nowrap; }
+.pat-card-stats .big { display: block; font-family: var(--font-display); font-style: italic; font-size: 22px; color: var(--ink); letter-spacing: -0.01em; }
+
+/* sparkline of recent activity */
+.sparkline { display: flex; align-items: flex-end; gap: 3px; height: 24px; margin-top: 6px; justify-content: flex-end; }
+.sparkline span { width: 6px; background: var(--terracotta-3); border-radius: 1px; }
+.sparkline span.is-month { background: var(--terracotta); }
+
+/* ============================================================
+   Pattern detail
+   ============================================================ */
+.pat-detail-head { padding-bottom: var(--sp-5); margin-bottom: var(--sp-6); border-bottom: 1px solid var(--border); }
+.pat-detail-name { font-family: var(--font-display); font-style: italic; font-size: clamp(2.4rem, 4vw, 3.2rem); line-height: 1.05; margin: 8px 0 4px; font-weight: 400; letter-spacing: -0.02em; }
+.pat-detail-desc { color: var(--ink-2); font-size: 17px; line-height: 1.55; margin: 0 0 var(--sp-4); max-width: 60ch; font-style: italic; font-family: var(--font-display); }
+.pat-detail-stats { display: flex; gap: var(--sp-6); font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; text-transform: uppercase; }
+.pat-detail-stats strong { display: block; font-family: var(--font-display); font-style: italic; font-size: 24px; color: var(--ink); letter-spacing: -0.01em; font-weight: 400; margin-top: 2px; text-transform: none; }
+
+/* typical quadrants */
+.typical {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg); padding: 4px;
+  margin-bottom: var(--sp-7);
+}
+.typical-q { padding: var(--sp-4); border-radius: var(--r-md); background: var(--paper); }
+.typical-q .q-eye { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.12em; text-transform: uppercase; }
+.typical-q .q-name { font-family: var(--font-display); font-style: italic; font-size: 18px; color: var(--ink); margin: 4px 0 8px; }
+.typical-q .q-text { font-size: 13.5px; color: var(--ink-2); line-height: 1.5; margin: 0; }
+
+/* occurrence timeline */
+.timeline { position: relative; padding-left: 32px; }
+.timeline::before {
+  content: ''; position: absolute; left: 11px; top: 6px; bottom: 6px;
+  width: 1px; background: var(--border); border-left: 1px dashed var(--border-strong); border-left-style: dashed;
+}
+.tl-item { position: relative; padding-bottom: var(--sp-5); }
+.tl-item::before {
+  content: ''; position: absolute; left: -28px; top: 6px;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--paper); border: 2px solid var(--terracotta);
+}
+.tl-item.is-recent::before { background: var(--terracotta); }
+.tl-date { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; margin-bottom: 4px; }
+.tl-trigger { font-family: var(--font-display); font-style: italic; font-size: 17px; color: var(--ink); margin: 0 0 6px; }
+.tl-quads { font-size: 13px; color: var(--ink-2); line-height: 1.55; max-width: 64ch; }
+.tl-quads em { color: var(--ink-3); font-family: var(--font-mono); font-style: normal; font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; margin-right: 4px; }
+
+/* ============================================================
+   Search
+   ============================================================ */
+.search-bar {
+  display: flex; align-items: center; gap: 12px;
+  background: var(--bg-elevated); border: 1px solid var(--border-strong);
+  border-radius: var(--r-md); padding: 14px 18px;
+  margin-bottom: var(--sp-5);
+  box-shadow: var(--shadow-xs);
+}
+.search-bar input {
+  flex: 1; background: transparent; border: none; outline: none;
+  font-family: var(--font-display); font-style: italic; font-size: 22px;
+  color: var(--ink); letter-spacing: -0.01em;
+}
+.search-bar input::placeholder { color: var(--ink-4); }
+.search-bar .hint { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; }
+
+.search-result {
+  padding: var(--sp-4) 0; border-top: 1px solid var(--border);
+  cursor: pointer; transition: all 120ms var(--ease-out);
+}
+.search-result:hover { background: rgba(124,122,181,0.04); padding-left: 8px; padding-right: 8px; margin-left: -8px; margin-right: -8px; border-radius: var(--r-sm); }
+.search-result-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
+.search-result-date { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; }
+.search-result-score { font-family: var(--font-mono); font-size: 10px; color: var(--terracotta); letter-spacing: 0.06em; }
+.search-result-snippet { font-size: 15px; line-height: 1.55; color: var(--ink-2); margin: 0; max-width: 64ch; }
+.search-result-snippet mark { background: var(--terracotta-3); color: var(--terracotta-2); padding: 1px 3px; border-radius: 2px; }
+
+/* ============================================================
+   Settings
+   ============================================================ */
+.set-section { padding: var(--sp-5) 0; border-top: 1px solid var(--border); display: grid; grid-template-columns: 220px 1fr; gap: var(--sp-6); align-items: start; }
+.set-section:first-of-type { border-top: none; padding-top: 0; }
+.set-label { font-family: var(--font-display); font-style: italic; font-size: 20px; color: var(--ink); margin: 0 0 4px; }
+.set-help { font-size: 13px; color: var(--ink-3); line-height: 1.5; margin: 0; max-width: 28ch; }
+.set-control { display: flex; flex-direction: column; gap: 12px; align-items: flex-start; }
+.set-control input[type="text"], .set-control select {
+  width: 280px; font-family: var(--font-body); font-size: 14px; color: var(--ink);
+  background: var(--paper-2); border: 1px solid var(--border); border-radius: var(--r-md);
+  padding: 10px 12px; outline: none;
+}
+.set-control input[type="text"]:focus, .set-control select:focus { border-color: var(--terracotta); background: var(--bg-elevated); }
+.toggle { display: inline-flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+.toggle-track { width: 40px; height: 22px; border-radius: 11px; background: var(--paper-3); position: relative; transition: all 220ms var(--ease-out); border: 1px solid var(--border); }
+.toggle-thumb { position: absolute; top: 1px; left: 1px; width: 18px; height: 18px; border-radius: 50%; background: var(--paper); transition: all 220ms var(--ease-out); box-shadow: var(--shadow-xs); }
+.toggle.on .toggle-track { background: var(--terracotta); border-color: var(--terracotta); }
+.toggle.on .toggle-thumb { left: 19px; }
+.toggle-label { font-size: 13.5px; color: var(--ink); }
+
+.btn { font-family: var(--font-body); font-weight: 500; border-radius: var(--r-sm); border: 1px solid transparent; cursor: pointer; transition: all 120ms var(--ease-out); display: inline-flex; align-items: center; gap: 8px; font-size: 14px; padding: 9px 16px; }
+.btn:active { transform: scale(0.98); }
+.btn-primary { background: var(--terracotta); color: var(--paper); }
+.btn-primary:hover { background: var(--terracotta-2); }
+.btn-secondary { background: transparent; color: var(--ink); border-color: var(--border-strong); }
+.btn-secondary:hover { background: var(--paper-2); }
+.btn-danger { background: transparent; color: var(--rust); border-color: var(--rust); }
+.btn-danger:hover { background: var(--rust); color: var(--paper); }
+.btn-md { font-size: 15px; padding: 10px 18px; }
+.btn-sm { font-size: 13px; padding: 6px 12px; }
+.btn-lg { font-size: 16px; padding: 13px 22px; }
+
+/* responsive */
+@media (max-width: 800px) {
+  .app { grid-template-columns: 1fr; }
+  .side { position: relative; height: auto; flex-direction: row; align-items: center; padding: var(--sp-3) var(--sp-4); flex-wrap: wrap; }
+  .side-search, .side-foot { display: none; }
+  .side-nav { flex-direction: row; flex-wrap: wrap; }
+  .side-eye { display: none; }
+  .main { padding: var(--sp-5) var(--sp-4); }
+  .entry-row { grid-template-columns: 1fr; gap: 10px; }
+  .occ-quads, .typical { grid-template-columns: 1fr; }
+}
+
+/* ============================================================
+   site.css — Landing page styles
+   ============================================================ */
+
+.site { display: flex; flex-direction: column; min-height: 100vh; }
+main { flex: 1; }
+section { padding: var(--sp-9) var(--sp-6); }
+.wrap { max-width: 1120px; margin: 0 auto; }
+
+/* ---------- Nav ---------- */
+.nav {
+  position: sticky; top: 0; z-index: 30;
+  display: flex; align-items: center; gap: var(--sp-6);
+  padding: var(--sp-4) var(--sp-6);
+  background: rgba(250,247,242,0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+}
+.nav-brand { display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--ink); }
+.nav-brand .wm { font-family: var(--font-display); font-size: 24px; line-height: 1; letter-spacing: -0.01em; }
+.nav-brand .wm em { font-style: italic; }
+.nav-brand .wm .dot { color: var(--terracotta); }
+.nav-links { display: flex; gap: var(--sp-5); flex: 1; margin-left: var(--sp-6); }
+.nav-link { font-size: 14px; color: var(--ink-2); text-decoration: none; padding: 6px 2px; border-bottom: 2px solid transparent; transition: all 120ms var(--ease-out); }
+.nav-link:hover { color: var(--ink); }
+.nav-link.is-active { color: var(--ink); border-bottom-color: var(--terracotta); }
+.nav-cta { display: flex; gap: var(--sp-2); align-items: center; }
+
+/* ---------- Eyebrow / micro ---------- */
+.eyebrow { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--ink-3); display: inline-flex; align-items: center; gap: 8px; }
+.eyebrow .glyph { color: var(--terracotta); }
+
+/* ============================================================
+   Hero
+   ============================================================ */
+.hero { padding: var(--sp-8) var(--sp-6) var(--sp-9); position: relative; overflow: hidden; }
+.hero-grid {
+  max-width: 1120px; margin: 0 auto;
+  display: grid; grid-template-columns: 1.15fr 1fr; gap: var(--sp-8);
+  align-items: center;
+}
+.hero-head {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 7vw, 5.6rem);
+  line-height: 1.04;
+  letter-spacing: -0.02em;
+  margin: var(--sp-4) 0 var(--sp-5);
+  text-wrap: balance;
+}
+.hero-head em { font-style: italic; color: var(--terracotta); }
+.hero-head .ink { color: var(--ink); }
+.hero-head .quiet { color: var(--ink-3); font-style: italic; }
+.hero-lede { font-size: 19px; color: var(--ink-2); line-height: 1.6; max-width: 52ch; margin: 0 0 var(--sp-6); text-wrap: pretty; }
+.hero-ctas { display: flex; gap: var(--sp-3); align-items: center; margin-bottom: var(--sp-6); flex-wrap: wrap; }
+.hero-meta { display: flex; gap: var(--sp-5); font-family: var(--font-mono); font-size: 12px; color: var(--ink-3); flex-wrap: wrap; }
+.hero-meta .dot { color: var(--terracotta); }
+
+/* Hero side: a small "today's entry" card peeking out */
+.hero-art { position: relative; min-height: 460px; }
+.hero-orbit {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+}
+.hero-orbit svg { width: 100%; max-width: 460px; opacity: 0.55; animation: drift 60s linear infinite; }
+@keyframes drift { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+
+.entry-peek {
+  position: absolute;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: var(--sp-5);
+  box-shadow: var(--shadow-md);
+  width: 320px;
+}
+.entry-peek-1 { top: 30px; right: 0; transform: rotate(2deg); }
+.entry-peek-2 { bottom: 20px; left: 0; transform: rotate(-3deg); width: 280px; padding: var(--sp-4); }
+.entry-peek h4 { font-family: var(--font-display); font-style: italic; font-size: 22px; margin: 0 0 4px; font-weight: 400; }
+.entry-peek .meta { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: var(--sp-3); display: flex; gap: var(--sp-3); align-items: center; }
+.entry-peek .meta .mood { color: var(--terracotta); }
+.entry-peek p { margin: 0; font-size: 14px; line-height: 1.55; color: var(--ink-2); }
+.entry-peek .tags { margin-top: var(--sp-3); display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* ============================================================
+   How it works — three small cards
+   ============================================================ */
+.how { background: var(--paper-2); }
+.section-head { max-width: 760px; margin: 0 auto var(--sp-7); }
+.section-head.center { text-align: center; }
+.section-title { font-family: var(--font-display); font-size: clamp(2.2rem, 4vw, 3.2rem); line-height: 1.05; margin: var(--sp-3) 0 var(--sp-4); text-wrap: balance; letter-spacing: -0.02em; font-weight: 400; }
+.section-title em { font-style: italic; color: var(--terracotta); }
+.section-sub { color: var(--ink-2); font-size: 18px; max-width: 60ch; line-height: 1.55; text-wrap: pretty; }
+.section-head.center .section-sub { margin: 0 auto; }
+
+.steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--sp-5); }
+.step {
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: var(--sp-6);
+  position: relative;
+  transition: all 220ms var(--ease-out);
+}
+.step:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
+.step-num { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: var(--sp-4); display: flex; align-items: center; justify-content: space-between; }
+.step-num .glyph { color: var(--terracotta); font-size: 14px; }
+.step h3 { font-family: var(--font-display); font-size: 28px; line-height: 1.15; margin: 0 0 var(--sp-3); font-weight: 400; letter-spacing: -0.01em; }
+.step h3 em { font-style: italic; color: var(--terracotta); }
+.step p { margin: 0; color: var(--ink-2); font-size: 15px; line-height: 1.6; }
+.step-cmd { margin-top: var(--sp-4); font-family: var(--font-mono); font-size: 12px; color: var(--slate); background: var(--paper-2); padding: 6px 10px; border-radius: var(--r-xs); display: inline-block; border: 1px solid var(--border); }
+
+/* ============================================================
+   Conversation — the centerpiece
+   ============================================================ */
+.conversation { padding-top: var(--sp-9); padding-bottom: var(--sp-9); position: relative; }
+.conv-grid {
+  max-width: 1180px; margin: 0 auto;
+  display: grid; grid-template-columns: 1fr 1.4fr; gap: var(--sp-8);
+  align-items: start;
+}
+.conv-text { position: sticky; top: 100px; }
+.conv-text .section-title { text-align: left; }
+
+.conv-list { list-style: none; padding: 0; margin: var(--sp-5) 0 var(--sp-6); display: flex; flex-direction: column; gap: var(--sp-4); }
+.conv-list li { display: flex; gap: var(--sp-3); font-size: 15px; color: var(--ink-2); line-height: 1.5; }
+.conv-list .mark { color: var(--terracotta); font-family: var(--font-mono); flex: none; padding-top: 2px; }
+.conv-list strong { color: var(--ink); font-weight: 500; }
+
+.conv-ctrls { display: flex; gap: var(--sp-3); align-items: center; flex-wrap: wrap; }
+.conv-ctrl-btn { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; padding: 7px 12px; border-radius: var(--r-pill); border: 1px solid var(--border-strong); background: transparent; color: var(--ink-2); cursor: pointer; transition: all 120ms var(--ease-out); }
+.conv-ctrl-btn:hover { background: var(--paper-2); color: var(--ink); }
+.conv-ctrl-btn.is-on { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+
+/* ---- The actual chat window ---- */
+.chat {
+  background: var(--bg-elevated);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  min-height: 640px;
+  border: 1px solid var(--border);
+}
+.chat-chrome {
+  display: flex; align-items: center; gap: var(--sp-3);
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--paper-2);
+}
+.chrome-dots { display: flex; gap: 6px; }
+.chrome-dots span { width: 10px; height: 10px; border-radius: 50%; background: var(--paper-3); }
+.chrome-dots span:first-child { background: #E8755A; opacity: 0.7; }
+.chrome-dots span:nth-child(2) { background: #E8B85A; opacity: 0.7; }
+.chrome-dots span:nth-child(3) { background: #6B9E5A; opacity: 0.6; }
+.chrome-title { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; flex: 1; text-align: center; display: flex; align-items: center; justify-content: center; gap: 8px; }
+.chrome-title .lock { opacity: 0.6; }
+.chrome-mcp {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em;
+  background: var(--paper); color: var(--ink-2); padding: 4px 9px;
+  border-radius: var(--r-pill); border: 1px solid var(--border);
+}
+.chrome-mcp .pulse { width: 6px; height: 6px; border-radius: 50%; background: var(--moss); animation: pulse 2s ease-in-out infinite; }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+.chat-body {
+  flex: 1; overflow-y: auto;
+  padding: var(--sp-6) var(--sp-6) var(--sp-4);
+  display: flex; flex-direction: column; gap: var(--sp-5);
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(217,119,87,0.04), transparent 60%),
+    var(--bg-elevated);
+  scroll-behavior: smooth;
+}
+
+.msg { display: flex; gap: var(--sp-3); max-width: 88%; opacity: 0; transform: translateY(8px); animation: msgIn 360ms var(--ease-out) forwards; }
+@keyframes msgIn { to { opacity: 1; transform: none; } }
+.msg-avatar { width: 32px; height: 32px; border-radius: 50%; flex: none; display: grid; place-items: center; font-family: var(--font-mono); font-size: 11px; font-weight: 600; }
+.msg-body { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.msg-from { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.1em; text-transform: uppercase; }
+.msg-text { font-size: 15.5px; line-height: 1.55; color: var(--ink); }
+.msg-text p { margin: 0 0 8px; }
+.msg-text p:last-child { margin: 0; }
+.msg-text em { font-family: var(--font-display); font-style: italic; font-size: 1.05em; color: var(--ink); }
+
+/* user message: right-aligned, paper-2 bubble */
+.msg.user { align-self: flex-end; flex-direction: row-reverse; }
+.msg.user .msg-avatar { background: var(--slate); color: var(--paper); }
+.msg.user .msg-body { align-items: flex-end; }
+.msg.user .msg-text {
+  background: var(--paper-2);
+  padding: 12px 16px;
+  border-radius: 18px 18px 4px 18px;
+  border: 1px solid var(--border);
+}
+
+/* kindred (assistant) message: left, no bubble */
+.msg.kindred .msg-avatar { background: var(--terracotta-3); color: var(--terracotta-2); }
+.msg.kindred .msg-text { padding-right: var(--sp-4); }
+
+/* slash command: pill-styled user input */
+.msg.slash .msg-text {
+  background: var(--ink); color: var(--paper);
+  padding: 8px 14px; border-radius: var(--r-pill);
+  font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.02em;
+  display: inline-flex; align-items: center; gap: 8px;
+  border: none;
+}
+.msg.slash .msg-text .cmd-glyph { color: var(--terracotta-3); }
+
+/* tool call card */
+.tool-call {
+  align-self: stretch; max-width: 100%;
+  background: var(--paper-2);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--terracotta);
+  border-radius: var(--r-md);
+  padding: var(--sp-3) var(--sp-4);
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--ink-2); line-height: 1.5;
+  opacity: 0; transform: translateY(8px); animation: msgIn 360ms var(--ease-out) forwards;
+}
+.tool-call .tc-head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; color: var(--ink-3); letter-spacing: 0.04em; }
+.tool-call .tc-head .arrow { color: var(--terracotta); }
+.tool-call .tc-name { color: var(--ink); font-weight: 500; }
+.tool-call .tc-args { color: var(--slate); }
+.tool-call .tc-result { margin-top: 6px; color: var(--moss); }
+
+/* typing indicator */
+.typing { display: inline-flex; gap: 4px; align-items: center; padding: 8px 0; }
+.typing span { width: 6px; height: 6px; border-radius: 50%; background: var(--ink-4); animation: bounce 1.4s ease-in-out infinite; }
+.typing span:nth-child(2) { animation-delay: 0.18s; }
+.typing span:nth-child(3) { animation-delay: 0.36s; }
+@keyframes bounce { 0%,80%,100% { transform: translateY(0); opacity: 0.4; } 40% { transform: translateY(-4px); opacity: 1; } }
+
+/* Input bar */
+.chat-input {
+  border-top: 1px solid var(--border);
+  background: var(--paper);
+  padding: 12px 16px;
+  display: flex; align-items: center; gap: var(--sp-3);
+}
+.chat-input .slash-hint {
+  font-family: var(--font-mono); font-size: 11px; color: var(--ink-3);
+  background: var(--paper-2); padding: 4px 8px; border-radius: var(--r-xs);
+  border: 1px solid var(--border); white-space: nowrap;
+}
+.chat-input input {
+  flex: 1; background: transparent; border: none; outline: none;
+  font-family: var(--font-body); font-size: 15px; color: var(--ink);
+  padding: 8px 0;
+}
+.chat-input input::placeholder { color: var(--ink-4); }
+.chat-input .send-btn {
+  width: 36px; height: 36px; border-radius: 50%;
+  background: var(--terracotta); color: var(--paper);
+  border: none; cursor: pointer; display: grid; place-items: center;
+  transition: all 120ms var(--ease-out);
+}
+.chat-input .send-btn:hover { background: var(--terracotta-2); }
+
+/* ============================================================
+   Patterns — The Hot Cross Bun framework
+   ============================================================ */
+.patterns { background: var(--paper-2); }
+.pat-grid {
+  max-width: 1120px; margin: 0 auto;
+  display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-8);
+  align-items: start;
+}
+.pat-text .section-title { text-align: left; }
+
+/* the bun itself */
+.bun {
+  position: relative;
+  aspect-ratio: 1;
+  max-width: 480px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2xl);
+  padding: var(--sp-2);
+  box-shadow: var(--shadow-sm);
+}
+.bun::before, .bun::after {
+  content: ''; position: absolute; background: var(--ink); pointer-events: none;
+}
+.bun::before { left: 50%; top: 12%; bottom: 12%; width: 1px; transform: translateX(-0.5px); opacity: 0.15; }
+.bun::after  { top: 50%; left: 12%; right: 12%; height: 1px; transform: translateY(-0.5px); opacity: 0.15; }
+.bun-q {
+  background: var(--paper);
+  border-radius: var(--r-lg);
+  padding: var(--sp-4);
+  display: flex; flex-direction: column; gap: 6px;
+  position: relative; z-index: 1;
+  transition: all 220ms var(--ease-out);
+}
+.bun-q:hover { background: var(--terracotta-3); }
+.bun-q .q-eye { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.12em; text-transform: uppercase; }
+.bun-q .q-name { font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.05; color: var(--ink); margin-bottom: 4px; }
+.bun-q .q-ex { font-size: 12.5px; color: var(--ink-2); line-height: 1.45; font-style: italic; }
+.bun-center {
+  position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+  width: 64px; height: 64px; border-radius: 50%;
+  background: var(--paper); border: 1px solid var(--border-strong);
+  display: grid; place-items: center; z-index: 2;
+  font-family: var(--font-mono); font-size: 9px; color: var(--ink-3);
+  letter-spacing: 0.1em; text-transform: uppercase; text-align: center;
+  line-height: 1.1;
+  box-shadow: var(--shadow-sm);
+}
+
+/* named pattern chips */
+.pat-named { margin-top: var(--sp-6); }
+.pat-named-h { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: var(--sp-3); }
+.pat-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.pat-chip {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--paper); border: 1px solid var(--border);
+  padding: 6px 12px 6px 10px; border-radius: var(--r-pill);
+  font-size: 13px; color: var(--ink);
+  font-family: var(--font-display); font-style: italic;
+}
+.pat-chip .count { font-family: var(--font-mono); font-style: normal; font-size: 10px; color: var(--ink-3); background: var(--paper-2); padding: 2px 6px; border-radius: var(--r-pill); border: 1px solid var(--border); }
+.pat-chip .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--terracotta); }
+
+/* ============================================================
+   Privacy strip
+   ============================================================ */
+.privacy { background: var(--paper); }
+.privacy-grid {
+  max-width: 1120px; margin: 0 auto;
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--sp-5);
+}
+.priv {
+  padding: var(--sp-5) 0;
+  border-top: 1px solid var(--ink);
+}
+.priv-eye { font-family: var(--font-mono); font-size: 10px; color: var(--ink-3); letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: var(--sp-3); }
+.priv h4 { font-family: var(--font-display); font-style: italic; font-size: 22px; line-height: 1.2; margin: 0 0 var(--sp-2); font-weight: 400; letter-spacing: -0.01em; }
+.priv p { margin: 0; color: var(--ink-2); font-size: 14px; line-height: 1.55; }
+
+/* ============================================================
+   Final CTA / footer
+   ============================================================ */
+.endcap {
+  background: var(--ink); color: var(--paper);
+  padding: var(--sp-9) var(--sp-6);
+  position: relative; overflow: hidden;
+}
+.endcap::before {
+  content: ''; position: absolute; inset: 0;
+  opacity: 0.18; filter: invert(1);
+}
+.endcap-inner { position: relative; max-width: 880px; margin: 0 auto; text-align: center; }
+.endcap h2 {
+  font-family: var(--font-display);
+  font-size: clamp(2.6rem, 5vw, 4.2rem);
+  line-height: 1.05; letter-spacing: -0.02em;
+  margin: 0 0 var(--sp-5);
+  font-weight: 400; text-wrap: balance;
+}
+.endcap h2 em { font-style: italic; color: var(--terracotta-3); }
+.endcap p { color: rgba(250,247,242,0.7); font-size: 18px; max-width: 52ch; margin: 0 auto var(--sp-6); line-height: 1.55; }
+
+.foot {
+  background: var(--ink); color: var(--paper);
+  padding: var(--sp-5) var(--sp-6);
+  border-top: 1px solid rgba(250,247,242,0.1);
+  font-family: var(--font-mono); font-size: 11px; color: rgba(250,247,242,0.5);
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: var(--sp-4);
+  letter-spacing: 0.04em;
+}
+.foot a { color: rgba(250,247,242,0.7); text-decoration: none; margin-right: var(--sp-4); }
+.foot a:hover { color: var(--terracotta-3); }
+
+/* ============================================================
+   Responsive
+   ============================================================ */
+@media (max-width: 960px) {
+  .hero-grid, .conv-grid, .pat-grid { grid-template-columns: 1fr; }
+  .conv-text { position: static; }
+  .steps, .privacy-grid { grid-template-columns: 1fr; }
+  .nav-links { display: none; }
+  section { padding: var(--sp-7) var(--sp-4); }
+  .entry-peek-1 { right: -10px; }
+  .hero-art { min-height: 380px; }
+}

--- a/web/frontend/src/main.tsx
+++ b/web/frontend/src/main.tsx
@@ -14,6 +14,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   })
 }
 import { Layout } from './components/Layout'
+import { Landing } from './pages/Landing'
 import { Login } from './pages/Login'
 import { Home } from './pages/Home'
 import { EntryDetail } from './pages/EntryDetail'
@@ -25,18 +26,22 @@ import { Connect } from './pages/Connect'
 import { McpAuth } from './pages/McpAuth'
 
 const router = createBrowserRouter([
+  // Public routes
+  { path: '/', element: <Landing /> },
+  { path: '/login', element: <Login /> },
   { path: '/mcp-auth', element: <McpAuth /> },
+  // Authenticated app routes
   {
+    path: '/app',
     element: <Layout />,
     children: [
-      { path: '/', element: <Home /> },
-      { path: '/login', element: <Login /> },
-      { path: '/entries/:id', element: <EntryDetail /> },
-      { path: '/patterns', element: <Patterns /> },
-      { path: '/patterns/:id', element: <PatternDetail /> },
-      { path: '/search', element: <Search /> },
-      { path: '/settings', element: <Settings /> },
-      { path: '/connect', element: <Connect /> },
+      { index: true, element: <Home /> },
+      { path: 'entries/:id', element: <EntryDetail /> },
+      { path: 'patterns', element: <Patterns /> },
+      { path: 'patterns/:id', element: <PatternDetail /> },
+      { path: 'search', element: <Search /> },
+      { path: 'settings', element: <Settings /> },
+      { path: 'connect', element: <Connect /> },
     ],
   },
 ])

--- a/web/frontend/src/pages/Connect.tsx
+++ b/web/frontend/src/pages/Connect.tsx
@@ -16,43 +16,155 @@ export function Connect() {
     }
   }
 
-  const copy = async () => {
-    if (!token) return
-    await navigator.clipboard.writeText(token.token)
+  const copy = async (text: string) => {
+    await navigator.clipboard.writeText(text)
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)
   }
 
+  const MCP_URL = import.meta.env.VITE_MCP_BASE_URL
+    ? `${import.meta.env.VITE_MCP_BASE_URL}/sse`
+    : 'https://kindred-mcp.interstellarai.net/sse'
+
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Connect to Claude.ai</h1>
-      <p className="text-sm text-stone-700">
-        Mint a connector token below and paste it into the Kindred connector
-        config in Claude.ai. Existing tokens stay valid.
-      </p>
-      <button
-        type="button"
-        onClick={() => void mint()}
-        className="rounded bg-stone-900 px-4 py-2 text-white hover:bg-stone-800"
+    <>
+      <div className="page-head">
+        <div className="page-eye">
+          <span className="glyph">◈</span> Connector
+        </div>
+        <h1 className="page-title">
+          Add Kindred to <em>Claude</em>.
+        </h1>
+        <p className="page-sub">
+          Two minutes. Paste this into Claude.ai&apos;s connector settings. Once connected, the
+          three slash commands light up.
+        </p>
+      </div>
+
+      <div
+        style={{
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--r-lg)',
+          padding: 'var(--sp-5)',
+          marginBottom: 'var(--sp-5)',
+        }}
       >
-        Mint new token
-      </button>
-      {error && <p className="text-red-700">{error}</p>}
-      {token && (
-        <div className="rounded border border-stone-200 bg-white p-4">
-          <div className="text-xs text-stone-500">Your new token:</div>
-          <code className="mt-2 block break-all rounded bg-stone-100 p-3 text-sm">
-            {token.token}
+        {/* Step 1 */}
+        <div className="entry-section-eye">Step 1 · MCP server URL</div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center',
+            marginBottom: 'var(--sp-4)',
+          }}
+        >
+          <code
+            style={{
+              flex: 1,
+              padding: '12px 14px',
+              background: 'var(--paper-2)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--r-md)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 13,
+              color: 'var(--ink)',
+              wordBreak: 'break-all',
+            }}
+          >
+            {MCP_URL}
           </code>
           <button
             type="button"
-            onClick={() => void copy()}
-            className="mt-3 rounded border border-stone-300 px-3 py-1 text-sm hover:bg-stone-100"
+            className="btn btn-secondary"
+            onClick={() => void copy(MCP_URL)}
           >
-            {copied ? 'Copied' : 'Copy'}
+            Copy
           </button>
         </div>
-      )}
-    </div>
+
+        {/* Step 2 */}
+        <div className="entry-section-eye">Step 2 · Connector token</div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center',
+            marginBottom: 'var(--sp-4)',
+          }}
+        >
+          {token ? (
+            <code
+              style={{
+                flex: 1,
+                padding: '12px 14px',
+                background: 'var(--paper-2)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--r-md)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 13,
+                color: 'var(--ink)',
+                wordBreak: 'break-all',
+              }}
+            >
+              {token.token}
+            </code>
+          ) : (
+            <code
+              style={{
+                flex: 1,
+                padding: '12px 14px',
+                background: 'var(--paper-2)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--r-md)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 13,
+                color: 'var(--ink-3)',
+              }}
+            >
+              kdr_••••••••••••••••••••••••
+            </code>
+          )}
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => void mint()}
+          >
+            {token ? 'Rotate' : 'Mint token'}
+          </button>
+          {token && (
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => void copy(token.token)}
+            >
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          )}
+        </div>
+
+        {error && (
+          <p style={{ color: 'var(--rust)', fontSize: 13, margin: '0 0 var(--sp-3)' }}>
+            {error}
+          </p>
+        )}
+
+        {/* Step 3 */}
+        <div className="entry-section-eye">Step 3 · Try it</div>
+        <p
+          style={{
+            color: 'var(--ink-2)',
+            fontSize: 14,
+            lineHeight: 1.55,
+            margin: '8px 0 0',
+            maxWidth: '56ch',
+          }}
+        >
+          In Claude.ai, type{' '}
+          <code>/kindred-start</code> to begin a session. That&apos;s it.
+        </p>
+      </div>
+    </>
   )
 }

--- a/web/frontend/src/pages/EntryDetail.tsx
+++ b/web/frontend/src/pages/EntryDetail.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import { api, type Entry } from '../api/client'
 
 export function EntryDetail() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const [entry, setEntry] = useState<Entry | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [showTranscript, setShowTranscript] = useState(false)
@@ -16,57 +17,112 @@ export function EntryDetail() {
       .catch((e: Error) => setError(e.message))
   }, [id])
 
-  if (error) return <p className="text-red-700">{error}</p>
-  if (!entry) return <p className="text-stone-500">Loading…</p>
+  if (error) return <p style={{ color: 'var(--rust)' }}>{error}</p>
+  if (!entry) return <p style={{ color: 'var(--ink-3)' }}>Loading…</p>
+
+  const fullDate = new Date(entry.date + 'T12:00').toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+
+  const transcriptCount = entry.transcript?.length ?? 0
 
   return (
-    <article className="prose max-w-none">
-      <div className="text-xs text-stone-500">{entry.date}</div>
-      {entry.mood && (
-        <div className="mt-1 text-sm text-stone-600">Mood: {entry.mood}</div>
-      )}
-      <p className="mt-4 whitespace-pre-wrap">{entry.summary}</p>
+    <>
+      <button className="back-link" type="button" onClick={() => void navigate(-1)}>
+        ← All entries
+      </button>
+
+      <div className="entry-detail-head">
+        <div>
+          <div className="page-eye">
+            <span className="glyph">◈</span> Entry
+          </div>
+          <div className="entry-detail-date">{fullDate}</div>
+        </div>
+        <div className="entry-detail-meta">
+          {entry.mood && <span className="mood-big">◉ {entry.mood}</span>}
+          {entry.transcript ? 'transcript on' : 'summary only'}
+        </div>
+      </div>
+
+      <p className="entry-summary">{entry.summary}</p>
 
       {entry.occurrences && entry.occurrences.length > 0 && (
-        <section className="mt-8">
-          <h2 className="text-lg font-semibold">Patterns this session</h2>
-          <ul className="mt-2 space-y-2">
-            {entry.occurrences.map((o) => (
-              <li
-                key={o.id}
-                className="rounded border border-stone-200 bg-white p-3 text-sm"
-              >
-                <div className="text-stone-500">Pattern: {o.pattern_id}</div>
-                {o.thoughts && <div>Thoughts: {o.thoughts}</div>}
-                {o.emotions && <div>Emotions: {o.emotions}</div>}
-                {o.behaviors && <div>Behaviors: {o.behaviors}</div>}
-                {o.sensations && <div>Sensations: {o.sensations}</div>}
-              </li>
-            ))}
-          </ul>
-        </section>
+        <>
+          <div className="entry-section-eye">Patterns named in this entry</div>
+          {entry.occurrences.map((o) => (
+            <div key={o.id} className="occ-card">
+              <div className="occ-head">
+                <span className="occ-name">
+                  <span className="glyph">✶</span>
+                  Pattern
+                </span>
+                {o.intensity != null && (
+                  <span className="occ-intensity">
+                    intensity {o.intensity}/5
+                    {o.trigger ? ` · trigger: ${o.trigger}` : ''}
+                  </span>
+                )}
+              </div>
+              <div className="occ-quads">
+                {o.thoughts && (
+                  <div className="occ-quad">
+                    <span className="occ-quad-label">Thoughts</span>
+                    {o.thoughts}
+                  </div>
+                )}
+                {o.emotions && (
+                  <div className="occ-quad">
+                    <span className="occ-quad-label">Emotions</span>
+                    {o.emotions}
+                  </div>
+                )}
+                {o.behaviors && (
+                  <div className="occ-quad">
+                    <span className="occ-quad-label">Behaviours</span>
+                    {o.behaviors}
+                  </div>
+                )}
+                {o.sensations && (
+                  <div className="occ-quad">
+                    <span className="occ-quad-label">Body</span>
+                    {o.sensations}
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </>
       )}
 
-      {entry.transcript && (
-        <section className="mt-8">
+      {entry.transcript && entry.transcript.length > 0 && (
+        <div className="transcript-wrap">
           <button
             type="button"
+            className={`transcript-toggle ${showTranscript ? 'is-open' : ''}`}
             onClick={() => setShowTranscript((v) => !v)}
-            className="text-sm text-stone-600 underline"
           >
-            {showTranscript ? 'Hide' : 'Show'} transcript
+            <span className="chev">▸</span>
+            {showTranscript ? 'Hide' : 'Show'} full transcript ({transcriptCount} messages)
           </button>
           {showTranscript && (
-            <div className="mt-2 space-y-2 text-sm">
+            <div className="transcript-body">
               {entry.transcript.map((m, i) => (
-                <div key={i}>
-                  <span className="font-semibold">{m.role}:</span> {m.content}
+                <div
+                  key={i}
+                  className={`t-msg ${m.role === 'assistant' ? 'kindred' : 'user'}`}
+                >
+                  <span className="who">{m.role === 'assistant' ? 'kindred' : 'you'}</span>
+                  <span className="text">{m.content}</span>
                 </div>
               ))}
             </div>
           )}
-        </section>
+        </div>
       )}
-    </article>
+    </>
   )
 }

--- a/web/frontend/src/pages/Home.tsx
+++ b/web/frontend/src/pages/Home.tsx
@@ -1,12 +1,29 @@
 import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router'
+import { Link } from 'react-router'
 import { api, type EntrySummary } from '../api/client'
+
+function formatEntryDate(dateStr: string) {
+  const d = new Date(dateStr + 'T12:00')
+  return {
+    day: d.getDate().toString(),
+    weekday: d.toLocaleDateString('en-US', { weekday: 'short' }),
+    month: d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }),
+  }
+}
+
+function groupByMonth(entries: EntrySummary[]): Record<string, EntrySummary[]> {
+  const groups: Record<string, EntrySummary[]> = {}
+  for (const entry of entries) {
+    const { month } = formatEntryDate(entry.date)
+    if (!groups[month]) groups[month] = []
+    groups[month].push(entry)
+  }
+  return groups
+}
 
 export function Home() {
   const [entries, setEntries] = useState<EntrySummary[] | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [query, setQuery] = useState('')
-  const navigate = useNavigate()
 
   useEffect(() => {
     api
@@ -15,47 +32,73 @@ export function Home() {
       .catch((e: Error) => setError(e.message))
   }, [])
 
-  const onSearch = (e: React.FormEvent) => {
-    e.preventDefault()
-    if (query.trim()) {
-      navigate(`/search?q=${encodeURIComponent(query.trim())}`)
-    }
-  }
+  if (error) return <p style={{ color: 'var(--rust)' }}>{error}</p>
+  if (entries === null) return <p style={{ color: 'var(--ink-3)' }}>Loading…</p>
+
+  const byMonth = groupByMonth(entries)
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Recent entries</h1>
-      <form onSubmit={onSearch} className="flex gap-2">
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search by feeling or theme…"
-          className="flex-1 rounded border border-stone-300 px-3 py-2"
-        />
-        <button
-          type="submit"
-          className="rounded bg-stone-900 px-4 py-2 text-white hover:bg-stone-800"
-        >
-          Search
-        </button>
-      </form>
-      {error && <p className="text-red-700">{error}</p>}
-      {entries === null && !error && <p className="text-stone-500">Loading…</p>}
-      {entries && entries.length === 0 && (
-        <p className="text-stone-500">
+    <>
+      <div className="page-head">
+        <div className="page-eye">
+          <span className="glyph">◈</span> Journal
+        </div>
+        <h1 className="page-title">
+          <em>library</em>
+        </h1>
+        <p className="page-sub">Your entries, kept quietly.</p>
+      </div>
+
+      <div className="readonly-banner">
+        <span className="lock">🔒</span>
+        <span>
+          <strong>Read-only.</strong> Entries are written through the journaling conversation in
+          Claude — not from here.
+        </span>
+      </div>
+
+      {entries.length === 0 && (
+        <p style={{ color: 'var(--ink-3)' }}>
           No entries yet. Start a journaling session in Claude.ai.
         </p>
       )}
-      <ul className="space-y-3">
-        {entries?.map((e) => (
-          <li key={e.id} className="rounded border border-stone-200 bg-white p-4">
-            <Link to={`/entries/${e.id}`} className="block">
-              <div className="text-xs text-stone-500">{e.date}</div>
-              <div className="mt-1 line-clamp-2">{e.summary}</div>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+
+      {Object.entries(byMonth).map(([month, items]) => (
+        <div key={month}>
+          <div className="month-div">{month}</div>
+          {items.map((entry) => {
+            const { day, weekday } = formatEntryDate(entry.date)
+            const title = entry.summary.length > 80
+              ? entry.summary.slice(0, 80) + '…'
+              : entry.summary
+            const body = entry.summary.length > 200
+              ? entry.summary.slice(0, 200) + '…'
+              : entry.summary
+
+            return (
+              <Link
+                key={entry.id}
+                to={`/entries/${entry.id}`}
+                style={{ textDecoration: 'none', color: 'inherit' }}
+              >
+                <div className="entry-row">
+                  <div className="entry-date">
+                    <span className="day">{day}</span>
+                    {weekday}
+                  </div>
+                  <div className="entry-body">
+                    <h3>{title}</h3>
+                    <p>{body}</p>
+                  </div>
+                  <div className="entry-meta">
+                    {entry.mood && <span className="mood">◉ {entry.mood}</span>}
+                  </div>
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      ))}
+    </>
   )
 }

--- a/web/frontend/src/pages/Home.tsx
+++ b/web/frontend/src/pages/Home.tsx
@@ -32,10 +32,7 @@ export function Home() {
       .catch((e: Error) => setError(e.message))
   }, [])
 
-  if (error) return <p style={{ color: 'var(--rust)' }}>{error}</p>
-  if (entries === null) return <p style={{ color: 'var(--ink-3)' }}>Loading…</p>
-
-  const byMonth = groupByMonth(entries)
+  const byMonth = entries ? groupByMonth(entries) : {}
 
   return (
     <>
@@ -49,6 +46,9 @@ export function Home() {
         <p className="page-sub">Your entries, kept quietly.</p>
       </div>
 
+      {error && <p style={{ color: 'var(--rust)' }}>{error}</p>}
+      {entries === null && <p style={{ color: 'var(--ink-3)' }}>Loading…</p>}
+
       <div className="readonly-banner">
         <span className="lock">🔒</span>
         <span>
@@ -57,7 +57,7 @@ export function Home() {
         </span>
       </div>
 
-      {entries.length === 0 && (
+      {entries?.length === 0 && (
         <p style={{ color: 'var(--ink-3)' }}>
           No entries yet. Start a journaling session in Claude.ai.
         </p>

--- a/web/frontend/src/pages/Landing.tsx
+++ b/web/frontend/src/pages/Landing.tsx
@@ -1,0 +1,765 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router'
+import { KindredMark } from '../components/Brand'
+
+/* ============================================================
+   Nav
+   ============================================================ */
+function Nav() {
+  return (
+    <nav className="nav">
+      <Link to="/" className="nav-brand" style={{ textDecoration: 'none' }}>
+        <KindredMark size={26} />
+        <span className="wm">
+          <em>Kindred</em>
+          <span className="dot">.</span>
+        </span>
+      </Link>
+      <div className="nav-links">
+        <a href="#how" className="nav-link">How it works</a>
+        <a href="#demo" className="nav-link">Demo</a>
+        <a href="#patterns" className="nav-link">Patterns</a>
+        <a href="#privacy" className="nav-link">Privacy</a>
+      </div>
+      <div className="nav-cta">
+        <Link to="/app" className="btn btn-primary btn-sm">Add to Claude</Link>
+      </div>
+    </nav>
+  )
+}
+
+/* ============================================================
+   Hero
+   ============================================================ */
+function Hero() {
+  return (
+    <section className="hero" id="home">
+      <div className="hero-grid">
+        <div className="hero-text">
+          <div className="eyebrow">
+            <span className="glyph">✶</span> Reflective journaling, via Claude
+          </div>
+          <h1 className="hero-head">
+            <span className="ink">A journal that</span>
+            <br />
+            <em>listens</em> <span className="ink">first.</span>
+          </h1>
+          <p className="hero-lede">
+            Kindred is reflective journaling through Claude — you talk, it stays with you.
+            Claude is the conversation; Kindred is the memory and the structure.
+            No mood scores, no streaks, no nudges. Just a quiet companion that remembers.
+          </p>
+          <div className="hero-ctas">
+            <button
+              className="btn btn-primary btn-lg"
+              type="button"
+              onClick={() =>
+                document.getElementById('demo')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+              }
+            >
+              See a session
+            </button>
+            <button
+              className="btn btn-link btn-md"
+              type="button"
+              onClick={() =>
+                document.getElementById('how')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+              }
+            >
+              How it works →
+            </button>
+          </div>
+          <div className="hero-meta">
+            <span>
+              <span className="dot">◉</span> MCP server
+            </span>
+            <span>✶ Read-only web app</span>
+            <span>· Your data, your vocabulary</span>
+          </div>
+        </div>
+
+        <div className="hero-art" aria-hidden="true">
+          <div className="hero-orbit">
+            <img src="/illustration-orbit.svg" alt="" />
+          </div>
+
+          <div className="entry-peek entry-peek-1">
+            <div className="meta">
+              <span>Apr 28 · Tue</span>
+              <span className="mood">◉ tender</span>
+            </div>
+            <h4>The Sunday-dread one, again</h4>
+            <p>
+              I noticed it earlier today than usual — somewhere around three. Not catastrophic.
+              More like a draft under a door.
+            </p>
+            <div className="tags">
+              <span className="tag-pill">sunday dread</span>
+              <span className="tag-pill">3rd this month</span>
+            </div>
+          </div>
+
+          <div className="entry-peek entry-peek-2">
+            <div className="meta">
+              <span>Apr 23 · Thu</span>
+              <span className="mood" style={{ color: 'var(--moss)' }}>
+                ◉ light
+              </span>
+            </div>
+            <h4>A good walk</h4>
+            <p>I think the trick is to go before I have a reason.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* ============================================================
+   How it works
+   ============================================================ */
+function HowItWorks() {
+  return (
+    <section className="how" id="how">
+      <div className="wrap">
+        <div className="section-head center">
+          <div className="eyebrow">
+            <span className="glyph">✶</span> How it works
+          </div>
+          <h2 className="section-title">
+            Three small <em>commands</em>. One quiet practice.
+          </h2>
+          <p className="section-sub">
+            Kindred lives inside Claude as a connector. Add it once, and three slash commands
+            appear — one to begin, one to look at a pattern, one to close.
+          </p>
+        </div>
+
+        <div className="steps">
+          <div className="step">
+            <div className="step-num">
+              <span>Step 01</span>
+              <span className="glyph">✶</span>
+            </div>
+            <h3>
+              <em>Begin</em> with a gentle question
+            </h3>
+            <p>
+              Claude greets you with one open prompt — &ldquo;How are you arriving today?&rdquo; —
+              and stays in listening mode. No advice, no reframing, no silver linings.
+            </p>
+            <span className="step-cmd">/kindred-start</span>
+          </div>
+          <div className="step">
+            <div className="step-num">
+              <span>Step 02</span>
+              <span className="glyph">✶</span>
+            </div>
+            <h3>
+              Examine a <em>pattern</em>, only if you want to
+            </h3>
+            <p>
+              When something feels worth pinning down, walk it through the four quadrants. Name the
+              pattern in your own words. Kindred remembers it for next time.
+            </p>
+            <span className="step-cmd">/kindred-hcb</span>
+          </div>
+          <div className="step">
+            <div className="step-num">
+              <span>Step 03</span>
+              <span className="glyph">✶</span>
+            </div>
+            <h3>
+              <em>Close</em> the session, gently
+            </h3>
+            <p>
+              Claude offers a one-paragraph summary in your language. You approve it. The entry
+              saves. No homework, no streak, no &ldquo;see you tomorrow!&rdquo;.
+            </p>
+            <span className="step-cmd">/kindred-close</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* ============================================================
+   Conversation demo
+   ============================================================ */
+type ScriptItem =
+  | { kind: 'slash'; from: string; text: string; delay: number }
+  | { kind: 'user' | 'kindred'; from: string; text: React.ReactNode; delay: number }
+  | { kind: 'tool'; delay: number; name: string; args: string; result: string }
+
+const SCRIPT: ScriptItem[] = [
+  { kind: 'slash', from: 'You', text: '/kindred-start', delay: 600 },
+  {
+    kind: 'kindred',
+    from: 'Kindred',
+    delay: 900,
+    text: (
+      <p>
+        <em>Hey. No agenda from my side — what&apos;s here for you right now?</em>
+      </p>
+    ),
+  },
+  {
+    kind: 'user',
+    from: 'You',
+    delay: 1100,
+    text: (
+      <p>
+        It&apos;s that Sunday feeling again, even though it&apos;s Thursday. A kind of low
+        static. I keep refreshing my email like that&apos;ll fix it.
+      </p>
+    ),
+  },
+  {
+    kind: 'kindred',
+    from: 'Kindred',
+    delay: 1300,
+    text: (
+      <>
+        <p>That sounds tiring — the static and the refreshing both.</p>
+        <p>
+          You said <em>&ldquo;Sunday feeling&rdquo;</em>, even on a Thursday. I&apos;m curious
+          what makes it feel like that one in particular, if you want to sit with it for a moment.
+        </p>
+      </>
+    ),
+  },
+  {
+    kind: 'user',
+    from: 'You',
+    delay: 1200,
+    text: (
+      <p>
+        I think it&apos;s the part where I&apos;m bracing for something I can&apos;t name. Like
+        there&apos;s a thing on my list I&apos;ve forgotten and I won&apos;t know until it&apos;s
+        too late.
+      </p>
+    ),
+  },
+  {
+    kind: 'kindred',
+    from: 'Kindred',
+    delay: 1300,
+    text: (
+      <p>
+        Bracing for an unnamed thing. That&apos;s a lot to carry quietly. Do you want to keep
+        talking about it as it is, or look at it more structurally — we could try /kindred-hcb if
+        it&apos;d help.
+      </p>
+    ),
+  },
+  { kind: 'slash', from: 'You', text: '/kindred-hcb', delay: 800 },
+  {
+    kind: 'tool',
+    delay: 700,
+    name: 'list_patterns',
+    args: '()',
+    result: '→ ["sunday dread", "the letting-people-down spiral"]',
+  },
+  {
+    kind: 'kindred',
+    from: 'Kindred',
+    delay: 1100,
+    text: (
+      <p>
+        Okay. Take it slow. <em>What were you telling yourself</em>, just before the static showed
+        up?
+      </p>
+    ),
+  },
+  {
+    kind: 'user',
+    from: 'You',
+    delay: 1100,
+    text: (
+      <p>
+        Something like — &ldquo;you&apos;re going to drop a ball and not realise.&rdquo; Plus a
+        quieter one underneath: &ldquo;people will be polite about it but they&apos;ll notice.&rdquo;
+      </p>
+    ),
+  },
+  {
+    kind: 'kindred',
+    from: 'Kindred',
+    delay: 1300,
+    text: (
+      <p>
+        Thank you for naming both. The quieter one feels like it has more weight. And in your body
+        — anything noticeable? Shoulders, breath, anywhere?
+      </p>
+    ),
+  },
+  {
+    kind: 'user',
+    from: 'You',
+    delay: 1000,
+    text: <p>Shallow breath. And my jaw is doing a thing.</p>,
+  },
+  {
+    kind: 'kindred',
+    from: 'Kindred',
+    delay: 1300,
+    text: (
+      <p>
+        Does this feel like the <em>&ldquo;Sunday dread&rdquo;</em> one you&apos;ve named before,
+        or something new?
+      </p>
+    ),
+  },
+  { kind: 'user', from: 'You', delay: 900, text: <p>Same one. Definitely.</p> },
+  {
+    kind: 'tool',
+    delay: 700,
+    name: 'log_occurrence',
+    args: '(pattern_name: "sunday dread", thoughts, emotions, …)',
+    result: '✓ saved · 4th occurrence',
+  },
+  {
+    kind: 'kindred',
+    from: 'Kindred',
+    delay: 1100,
+    text: <p>Logged. Want to keep talking, or close out for now?</p>,
+  },
+]
+
+function Conversation() {
+  const [step, setStep] = useState(0)
+  const [playing, setPlaying] = useState(true)
+  const [typing, setTyping] = useState(false)
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!playing) return
+    if (step >= SCRIPT.length) return
+
+    const item = SCRIPT[step]
+    const showTyping = item.kind === 'kindred'
+    if (showTyping) {
+      setTyping(true)
+      timerRef.current = setTimeout(() => {
+        setTyping(false)
+        setStep((s) => s + 1)
+      }, item.delay)
+    } else {
+      timerRef.current = setTimeout(() => {
+        setStep((s) => s + 1)
+      }, item.delay)
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [step, playing])
+
+  useEffect(() => {
+    const el = bodyRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [step, typing])
+
+  const replay = () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setStep(0)
+    setTyping(false)
+    setPlaying(true)
+  }
+
+  const togglePlay = () => {
+    if (step >= SCRIPT.length) {
+      replay()
+      return
+    }
+    setPlaying((p) => !p)
+  }
+
+  const visible = SCRIPT.slice(0, step)
+  const done = step >= SCRIPT.length
+
+  return (
+    <section className="conversation" id="demo">
+      <div className="conv-grid">
+        <div className="conv-text">
+          <div className="eyebrow">
+            <span className="glyph">✶</span> A real session, more or less
+          </div>
+          <h2 className="section-title">
+            It&apos;s Claude. With <em>somewhere</em> for it to land.
+          </h2>
+          <p className="section-sub">
+            You journal by talking to Claude. Kindred adds the parts a journal needs: a place to
+            keep entries, a way to name recurring patterns, and tools that only run when you ask
+            them to.
+          </p>
+          <ul className="conv-list">
+            <li>
+              <span className="mark">01</span>
+              <span>
+                <strong>Validation before analysis.</strong> The default stance is being-with, not
+                problem-solving.
+              </span>
+            </li>
+            <li>
+              <span className="mark">02</span>
+              <span>
+                <strong>You own the vocabulary.</strong> Patterns are named in your words. The AI
+                suggests; never imposes.
+              </span>
+            </li>
+            <li>
+              <span className="mark">03</span>
+              <span>
+                <strong>No surveillance.</strong> Past entries stay quiet unless you ask.
+              </span>
+            </li>
+            <li>
+              <span className="mark">04</span>
+              <span>
+                <strong>One write path.</strong> The web app reads. The conversation is where
+                things are written.
+              </span>
+            </li>
+          </ul>
+          <div className="conv-ctrls">
+            <button
+              type="button"
+              className={`conv-ctrl-btn ${playing && !done ? 'is-on' : ''}`}
+              onClick={togglePlay}
+            >
+              {done ? '↻ Replay' : playing ? '❚❚ Pause' : '▶ Play'}
+            </button>
+            <button type="button" className="conv-ctrl-btn" onClick={replay}>
+              ↻ Restart
+            </button>
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                color: 'var(--ink-3)',
+                letterSpacing: '0.06em',
+              }}
+            >
+              {Math.min(step, SCRIPT.length)} / {SCRIPT.length}
+            </span>
+          </div>
+        </div>
+
+        <div className="chat" role="region" aria-label="Demo conversation">
+          <div className="chat-chrome">
+            <div className="chrome-dots">
+              <span />
+              <span />
+              <span />
+            </div>
+            <div className="chrome-title">
+              <span className="lock">🔒</span>
+              claude.ai · journal — Thursday, 1:48 PM
+            </div>
+            <div className="chrome-mcp">
+              <span className="pulse" />
+              {' '}kindred · mcp
+            </div>
+          </div>
+
+          <div className="chat-body" ref={bodyRef}>
+            {visible.map((m, i) => {
+              if (m.kind === 'tool') {
+                return (
+                  <div key={i} className="tool-call">
+                    <div className="tc-head">
+                      <span className="arrow">→</span>
+                      <span>kindred mcp call</span>
+                    </div>
+                    <div>
+                      <span className="tc-name">{m.name}</span>
+                      <span className="tc-args">{m.args}</span>
+                    </div>
+                    <div className="tc-result">{m.result}</div>
+                  </div>
+                )
+              }
+              if (m.kind === 'slash') {
+                return (
+                  <div key={i} className="msg slash user">
+                    <div className="msg-avatar" aria-hidden="true">A</div>
+                    <div className="msg-body">
+                      <span className="msg-from">{m.from}</span>
+                      <div className="msg-text">
+                        <span className="cmd-glyph">/</span>
+                        {m.text.slice(1)}
+                      </div>
+                    </div>
+                  </div>
+                )
+              }
+              return (
+                <div key={i} className={`msg ${m.kind}`}>
+                  <div className="msg-avatar" aria-hidden="true">
+                    {m.kind === 'kindred' ? 'K' : 'A'}
+                  </div>
+                  <div className="msg-body">
+                    <span className="msg-from">{m.from}</span>
+                    <div className="msg-text">{m.text}</div>
+                  </div>
+                </div>
+              )
+            })}
+            {typing && (
+              <div className="msg kindred">
+                <div className="msg-avatar" aria-hidden="true">K</div>
+                <div className="msg-body">
+                  <span className="msg-from">Kindred</span>
+                  <div className="typing">
+                    <span />
+                    <span />
+                    <span />
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <form className="chat-input" onSubmit={(e) => e.preventDefault()}>
+            <span className="slash-hint">/ type a slash command</span>
+            <input
+              type="text"
+              placeholder={done ? 'Try /kindred-close to wrap up…' : 'Or just keep talking.'}
+            />
+            <button type="submit" className="send-btn" aria-label="Send">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.25"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M5 12h14M13 6l6 6-6 6" />
+              </svg>
+            </button>
+          </form>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* ============================================================
+   Patterns — Hot Cross Bun
+   ============================================================ */
+function PatternsSection() {
+  return (
+    <section className="patterns" id="patterns">
+      <div className="wrap pat-grid">
+        <div className="pat-text">
+          <div className="eyebrow">
+            <span className="glyph">✶</span> The Hot Cross Bun
+          </div>
+          <h2 className="section-title">
+            A small framework, <em>only</em> when you reach for it.
+          </h2>
+          <p className="section-sub">
+            Borrowed from CBT, used gently. Four quadrants — thoughts, emotions, behaviours, body
+            — to help name what&apos;s actually here. You name the pattern. Kindred keeps a list.
+          </p>
+
+          <div className="pat-named">
+            <div className="pat-named-h">A few you might name</div>
+            <div className="pat-chips">
+              <span className="pat-chip">
+                <span className="dot" />
+                Sunday dread <span className="count">×4</span>
+              </span>
+              <span className="pat-chip">
+                <span className="dot" />
+                The letting-people-down spiral <span className="count">×2</span>
+              </span>
+              <span className="pat-chip">
+                <span className="dot" />
+                3pm wall <span className="count">×7</span>
+              </span>
+              <span className="pat-chip">
+                <span className="dot" />
+                The one about my dad <span className="count">×1</span>
+              </span>
+              <span className="pat-chip">
+                <span className="dot" />
+                Pre-trip jangle <span className="count">×3</span>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="bun" aria-label="Hot Cross Bun framework">
+          <div className="bun-q">
+            <span className="q-eye">Quadrant 01</span>
+            <span className="q-name">Thoughts</span>
+            <span className="q-ex">&ldquo;What was I telling myself?&rdquo;</span>
+          </div>
+          <div className="bun-q">
+            <span className="q-eye">Quadrant 02</span>
+            <span className="q-name">Emotions</span>
+            <span className="q-ex">&ldquo;How did I feel — your word, not a label.&rdquo;</span>
+          </div>
+          <div className="bun-q">
+            <span className="q-eye">Quadrant 03</span>
+            <span className="q-name">Behaviours</span>
+            <span className="q-ex">&ldquo;What did I do, or not do?&rdquo;</span>
+          </div>
+          <div className="bun-q">
+            <span className="q-eye">Quadrant 04</span>
+            <span className="q-name">Body</span>
+            <span className="q-ex">
+              &ldquo;What was happening physically — breath, jaw, shoulders.&rdquo;
+            </span>
+          </div>
+          <div className="bun-center">HCB</div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* ============================================================
+   Privacy
+   ============================================================ */
+function Privacy() {
+  return (
+    <section className="privacy" id="privacy">
+      <div className="wrap">
+        <div className="section-head">
+          <div className="eyebrow">
+            <span className="glyph">✶</span> Boring privacy claims, kept honest
+          </div>
+          <h2 className="section-title">
+            Your <em>journal</em>. Not our dataset.
+          </h2>
+        </div>
+        <div className="privacy-grid">
+          <div className="priv">
+            <div className="priv-eye">01 / Encrypted at rest</div>
+            <h4>Stored on Supabase, scoped to you.</h4>
+            <p>
+              Row-level security on every table — cross-user reads are physically impossible from
+              app code, even if a query forgets a where-clause.
+            </p>
+          </div>
+          <div className="priv">
+            <div className="priv-eye">02 / No training</div>
+            <h4>Your words don&apos;t train anything.</h4>
+            <p>
+              We don&apos;t train models, and we pick providers with no-training policies. We{' '}
+              <em>don&apos;t</em> claim end-to-end — the LLM has to read what you write.
+            </p>
+          </div>
+          <div className="priv">
+            <div className="priv-eye">03 / No surveillance</div>
+            <h4>The AI won&apos;t volunteer your past.</h4>
+            <p>
+              &ldquo;You&apos;ve felt this way 5 Sundays in a row&rdquo; — never. Past entries
+              surface only when you ask for them, in the conversation or the web app.
+            </p>
+          </div>
+          <div className="priv">
+            <div className="priv-eye">04 / One way out</div>
+            <h4>Export everything. Delete it all.</h4>
+            <p>
+              Two buttons in settings. Export gives a JSON dump of every entry, pattern, and
+              occurrence. Delete is a hard cascade. No &ldquo;are you sure&rdquo; theatre.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* ============================================================
+   EndCap + Footer
+   ============================================================ */
+function EndCap() {
+  return (
+    <>
+      <section className="endcap" id="start">
+        <div className="endcap-inner">
+          <div className="eyebrow" style={{ color: 'rgba(250,247,242,0.5)' }}>
+            <span className="glyph" style={{ color: 'var(--terracotta-3)' }}>
+              ✶
+            </span>{' '}
+            Ready when you are
+          </div>
+          <h2>
+            Talk to Claude. Let <em>Kindred</em> hold the rest.
+          </h2>
+          <p>
+            Add the connector to Claude.ai, sign in with Google, type{' '}
+            <code
+              style={{
+                background: 'rgba(250,247,242,0.08)',
+                color: 'var(--paper)',
+                padding: '2px 6px',
+                borderRadius: 4,
+                fontFamily: 'var(--font-mono)',
+                fontSize: 14,
+              }}
+            >
+              /kindred-start
+            </code>
+            . That&apos;s the whole onboarding.
+          </p>
+          <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+            <Link to="/app" className="btn btn-primary btn-lg">
+              Connect to Claude.ai
+            </Link>
+            <button
+              type="button"
+              className="btn btn-ghost btn-lg"
+              style={{ color: 'var(--paper)', border: '1px solid rgba(250,247,242,0.25)' }}
+              onClick={() =>
+                document.getElementById('how')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+              }
+            >
+              How it works →
+            </button>
+          </div>
+        </div>
+      </section>
+      <footer className="foot">
+        <div>
+          <span style={{ color: 'var(--terracotta-3)' }}>✶</span> Kindred — a small thing made by
+          InterstellarAI
+        </div>
+        <div>
+          <a href="#privacy">Privacy</a>
+          <a href="#">Terms</a>
+          <a href="#">Field notes</a>
+        </div>
+        <div>Made in orbit · v0.1</div>
+      </footer>
+    </>
+  )
+}
+
+/* ============================================================
+   Landing page (assembled)
+   ============================================================ */
+export function Landing() {
+  return (
+    <div className="site">
+      <Nav />
+      <main>
+        <Hero />
+        <HowItWorks />
+        <Conversation />
+        <PatternsSection />
+        <Privacy />
+        <EndCap />
+      </main>
+    </div>
+  )
+}

--- a/web/frontend/src/pages/Login.tsx
+++ b/web/frontend/src/pages/Login.tsx
@@ -1,31 +1,89 @@
 import { Navigate } from 'react-router'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../store/auth'
+import { KindredMark } from '../components/Brand'
 
 export function Login() {
   const session = useAuth((s) => s.session)
-  if (session) return <Navigate to="/" replace />
+  if (session) return <Navigate to="/app" replace />
 
   const signIn = () => {
     void supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: { redirectTo: window.location.origin + '/' },
+      options: { redirectTo: window.location.origin + '/app' },
     })
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-stone-50">
-      <div className="w-full max-w-sm space-y-6 rounded-lg border border-stone-200 bg-white p-8 text-center shadow-sm">
-        <div>
-          <h1 className="text-2xl font-semibold">Kindred</h1>
-          <p className="mt-2 text-sm text-stone-600">
-            A reflective journaling companion.
-          </p>
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--paper)',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 380,
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--r-xl)',
+          padding: 'var(--sp-7)',
+          boxShadow: 'var(--shadow-md)',
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 10,
+            marginBottom: 'var(--sp-6)',
+          }}
+        >
+          <KindredMark size={36} />
+          <span
+            style={{
+              fontFamily: 'var(--font-display)',
+              fontSize: 28,
+              lineHeight: 1,
+              letterSpacing: '-0.01em',
+            }}
+          >
+            <em>Kindred</em>
+            <span style={{ color: 'var(--terracotta)' }}>.</span>
+          </span>
         </div>
+
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 'var(--fs-h3)',
+            fontWeight: 400,
+            margin: '0 0 var(--sp-2)',
+          }}
+        >
+          Sign in to your <em>journal</em>
+        </h1>
+        <p
+          style={{
+            color: 'var(--ink-3)',
+            fontSize: 'var(--fs-sm)',
+            marginBottom: 'var(--sp-6)',
+          }}
+        >
+          A reflective journaling companion.
+        </p>
+
         <button
           type="button"
+          className="btn btn-primary btn-lg"
           onClick={signIn}
-          className="w-full rounded bg-stone-900 px-4 py-2 text-white hover:bg-stone-800"
+          style={{ width: '100%', justifyContent: 'center' }}
         >
           Sign in with Google
         </button>

--- a/web/frontend/src/pages/McpAuth.tsx
+++ b/web/frontend/src/pages/McpAuth.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { supabase } from '../lib/supabase'
+import { KindredMark } from '../components/Brand'
 
 const MCP_BASE = import.meta.env.VITE_MCP_BASE_URL ?? 'https://kindred-mcp.interstellarai.net'
 
 export function McpAuth() {
-  const [status, setStatus] = useState<'starting' | 'completing' | 'error'>('starting')
+  const [status, setStatus] = useState<'starting' | 'completing' | 'done' | 'error'>('starting')
   const [errorMsg, setErrorMsg] = useState('')
   const ran = useRef(false)
 
@@ -49,6 +50,7 @@ export function McpAuth() {
         }
         const { redirect_url } = (await resp.json()) as { redirect_url: string }
         sessionStorage.removeItem('mcp_flow_id')
+        setStatus('done')
         window.location.href = redirect_url
       } catch (err) {
         setStatus('error')
@@ -75,21 +77,110 @@ export function McpAuth() {
     return () => subscription.unsubscribe()
   }, [])
 
+  const cardStyle: React.CSSProperties = {
+    width: '100%',
+    maxWidth: 380,
+    background: 'var(--bg-elevated)',
+    border: '1px solid var(--border)',
+    borderRadius: 'var(--r-xl)',
+    padding: 'var(--sp-7)',
+    boxShadow: 'var(--shadow-md)',
+    textAlign: 'center',
+  }
+
+  const wrapStyle: React.CSSProperties = {
+    minHeight: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'var(--paper)',
+  }
+
+  const brandRow = (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 10,
+        marginBottom: 'var(--sp-5)',
+      }}
+    >
+      <KindredMark size={32} />
+      <span
+        style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: 24,
+          lineHeight: 1,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        <em>Kindred</em>
+        <span style={{ color: 'var(--terracotta)' }}>.</span>
+      </span>
+    </div>
+  )
+
   if (status === 'error') {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-stone-50">
-        <div className="w-full max-w-sm rounded-lg border border-red-200 bg-white p-8 text-center shadow-sm">
-          <h2 className="text-lg font-semibold text-red-700">Connection failed</h2>
-          <p className="mt-2 text-sm text-stone-600">{errorMsg}</p>
+      <div style={wrapStyle}>
+        <div style={{ ...cardStyle, borderColor: 'var(--rust)', borderLeftWidth: 3 }}>
+          {brandRow}
+          <h2
+            style={{
+              fontFamily: 'var(--font-display)',
+              fontWeight: 400,
+              fontSize: 'var(--fs-h3)',
+              color: 'var(--rust)',
+              margin: '0 0 var(--sp-3)',
+            }}
+          >
+            Connection failed
+          </h2>
+          <p style={{ color: 'var(--ink-3)', fontSize: 'var(--fs-sm)', margin: 0 }}>
+            {errorMsg}
+          </p>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-stone-50">
-      <div className="text-center text-stone-600">
-        {status === 'completing' ? 'Completing authentication…' : 'Connecting to Claude…'}
+    <div style={wrapStyle}>
+      <div style={cardStyle}>
+        {brandRow}
+        <p
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--ink-3)',
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            margin: '0 0 var(--sp-3)',
+          }}
+        >
+          {status === 'completing' ? 'Completing authentication…' : 'Connecting to Claude…'}
+        </p>
+        <div
+          style={{
+            display: 'inline-flex',
+            gap: 6,
+            alignItems: 'center',
+          }}
+        >
+          {[0, 0.18, 0.36].map((delay, i) => (
+            <span
+              key={i}
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                background: 'var(--moss)',
+                animation: `bounce 1.4s ease-in-out ${delay}s infinite`,
+              }}
+            />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/web/frontend/src/pages/PatternDetail.tsx
+++ b/web/frontend/src/pages/PatternDetail.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router'
+import { Link, useNavigate, useParams } from 'react-router'
 import { api, type Pattern } from '../api/client'
 
 export function PatternDetail() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const [pattern, setPattern] = useState<Pattern | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -15,40 +16,105 @@ export function PatternDetail() {
       .catch((e: Error) => setError(e.message))
   }, [id])
 
-  if (error) return <p className="text-red-700">{error}</p>
-  if (!pattern) return <p className="text-stone-500">Loading…</p>
+  if (error) return <p style={{ color: 'var(--rust)' }}>{error}</p>
+  if (!pattern) return <p style={{ color: 'var(--ink-3)' }}>Loading…</p>
+
+  const lastSeen = new Date(pattern.last_seen_at).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
 
   return (
-    <article className="prose max-w-none">
-      <h1>{pattern.name}</h1>
-      {pattern.description && <p>{pattern.description}</p>}
-      <section className="not-prose mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <Quadrant title="Typical thoughts" value={pattern.typical_thoughts} />
-        <Quadrant title="Typical emotions" value={pattern.typical_emotions} />
-        <Quadrant title="Typical behaviors" value={pattern.typical_behaviors} />
-        <Quadrant title="Typical sensations" value={pattern.typical_sensations} />
-      </section>
-      <h2 className="mt-8">Occurrences</h2>
-      <ul className="space-y-3">
-        {pattern.occurrences?.map((o) => (
-          <li key={o.id} className="rounded border border-stone-200 bg-white p-4 text-sm">
-            <div className="text-xs text-stone-500">{o.date}</div>
-            {o.thoughts && <div>Thoughts: {o.thoughts}</div>}
-            {o.emotions && <div>Emotions: {o.emotions}</div>}
-            {o.behaviors && <div>Behaviors: {o.behaviors}</div>}
-            {o.sensations && <div>Sensations: {o.sensations}</div>}
-          </li>
-        ))}
-      </ul>
-    </article>
-  )
-}
+    <>
+      <button className="back-link" type="button" onClick={() => void navigate(-1)}>
+        ← All patterns
+      </button>
 
-function Quadrant({ title, value }: { title: string; value: string | null }) {
-  return (
-    <div className="rounded border border-stone-200 bg-white p-4">
-      <div className="text-xs uppercase tracking-wide text-stone-500">{title}</div>
-      <div className="mt-1 text-sm">{value || '—'}</div>
-    </div>
+      <div className="pat-detail-head">
+        <div className="page-eye">
+          <span className="glyph">◈</span> Pattern
+        </div>
+        <h1 className="pat-detail-name">{pattern.name}</h1>
+        {pattern.description && (
+          <p className="pat-detail-desc">{pattern.description}</p>
+        )}
+        <div className="pat-detail-stats">
+          <div>
+            Occurrences
+            <strong>×{pattern.occurrence_count}</strong>
+          </div>
+          <div>
+            Last seen
+            <strong>{lastSeen}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div className="entry-section-eye">The typical shape</div>
+      <div className="typical">
+        <div className="typical-q">
+          <span className="q-eye">Quadrant 01</span>
+          <div className="q-name">Thoughts</div>
+          <p className="q-text">{pattern.typical_thoughts ?? '—'}</p>
+        </div>
+        <div className="typical-q">
+          <span className="q-eye">Quadrant 02</span>
+          <div className="q-name">Emotions</div>
+          <p className="q-text">{pattern.typical_emotions ?? '—'}</p>
+        </div>
+        <div className="typical-q">
+          <span className="q-eye">Quadrant 03</span>
+          <div className="q-name">Behaviours</div>
+          <p className="q-text">{pattern.typical_behaviors ?? '—'}</p>
+        </div>
+        <div className="typical-q">
+          <span className="q-eye">Quadrant 04</span>
+          <div className="q-name">Body</div>
+          <p className="q-text">{pattern.typical_sensations ?? '—'}</p>
+        </div>
+      </div>
+
+      {pattern.occurrences && pattern.occurrences.length > 0 && (
+        <>
+          <div className="entry-section-eye">When it has shown up</div>
+          <div className="timeline">
+            {pattern.occurrences.map((o, i) => {
+              const occDate = new Date(o.date + 'T12:00').toLocaleDateString('en-US', {
+                month: 'long',
+                day: 'numeric',
+              })
+              return (
+                <div key={o.id} className={`tl-item ${i === 0 ? 'is-recent' : ''}`}>
+                  <div className="tl-date">
+                    {occDate}
+                    {o.intensity != null && ` · intensity ${o.intensity}/5`}
+                    {' · '}
+                    <Link to={`/entries/${o.entry_id}`} style={{ color: 'var(--terracotta)' }}>
+                      read entry →
+                    </Link>
+                  </div>
+                  {o.trigger && <p className="tl-trigger">Trigger: {o.trigger}</p>}
+                  <div className="tl-quads">
+                    {o.thoughts && (
+                      <div>
+                        <em>Thoughts</em>
+                        {o.thoughts}
+                      </div>
+                    )}
+                    {o.sensations && (
+                      <div style={{ marginTop: 6 }}>
+                        <em>Body</em>
+                        {o.sensations}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </>
   )
 }

--- a/web/frontend/src/pages/Patterns.tsx
+++ b/web/frontend/src/pages/Patterns.tsx
@@ -13,31 +13,66 @@ export function Patterns() {
       .catch((e: Error) => setError(e.message))
   }, [])
 
-  if (error) return <p className="text-red-700">{error}</p>
-  if (!patterns) return <p className="text-stone-500">Loading…</p>
+  if (error) return <p style={{ color: 'var(--rust)' }}>{error}</p>
+  if (!patterns) return <p style={{ color: 'var(--ink-3)' }}>Loading…</p>
+
+  const sorted = [...patterns].sort(
+    (a, b) => new Date(b.last_seen_at).getTime() - new Date(a.last_seen_at).getTime(),
+  )
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Patterns</h1>
+    <>
+      <div className="page-head">
+        <div className="page-eye">
+          <span className="glyph">◈</span> Patterns
+        </div>
+        <h1 className="page-title">
+          What <em>keeps</em> coming back
+        </h1>
+        <p className="page-sub">
+          Sorted by when you last saw them. Each one is named in your words.
+        </p>
+      </div>
+
+      <div className="readonly-banner">
+        <span className="lock">🔒</span>
+        <span>
+          <strong>Read-only.</strong> Patterns are named during your journaling sessions in Claude.
+        </span>
+      </div>
+
       {patterns.length === 0 && (
-        <p className="text-stone-500">
-          No named patterns yet. They'll appear once /kindred-hcb logs an
-          occurrence.
+        <p style={{ color: 'var(--ink-3)' }}>
+          No named patterns yet. They&apos;ll appear once /kindred-hcb logs an occurrence.
         </p>
       )}
-      <ul className="space-y-3">
-        {patterns.map((p) => (
-          <li key={p.id} className="rounded border border-stone-200 bg-white p-4">
-            <Link to={`/patterns/${p.id}`} className="block">
-              <div className="font-semibold">{p.name}</div>
-              <div className="mt-1 text-xs text-stone-500">
-                last seen {new Date(p.last_seen_at).toLocaleDateString()} ·{' '}
-                {p.occurrence_count} occurrences
+
+      <div className="pat-list">
+        {sorted.map((p) => {
+          const lastSeen = new Date(p.last_seen_at).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+          })
+          return (
+            <Link
+              key={p.id}
+              to={`/patterns/${p.id}`}
+              style={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              <div className="pat-card">
+                <div>
+                  <h3 className="pat-card-name">{p.name}</h3>
+                  {p.description && <p className="pat-card-desc">{p.description}</p>}
+                </div>
+                <div className="pat-card-stats">
+                  <span className="big">×{p.occurrence_count}</span>
+                  last seen {lastSeen}
+                </div>
               </div>
             </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+          )
+        })}
+      </div>
+    </>
   )
 }

--- a/web/frontend/src/pages/Search.tsx
+++ b/web/frontend/src/pages/Search.tsx
@@ -1,12 +1,38 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router'
 import { api, type SearchHit } from '../api/client'
 
+function SearchIcon() {
+  return (
+    <svg
+      width={20}
+      height={20}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ color: 'var(--ink-3)', flexShrink: 0 }}
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="M21 21l-5-5" />
+    </svg>
+  )
+}
+
 export function Search() {
-  const [params] = useSearchParams()
+  const [params, setParams] = useSearchParams()
   const q = params.get('q') ?? ''
+  const [inputVal, setInputVal] = useState(q)
   const [hits, setHits] = useState<SearchHit[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Sync inputVal when URL param changes
+  useEffect(() => {
+    setInputVal(q)
+  }, [q])
 
   useEffect(() => {
     if (!q.trim()) {
@@ -20,27 +46,78 @@ export function Search() {
       .catch((e: Error) => setError(e.message))
   }, [q])
 
+  const handleChange = (val: string) => {
+    setInputVal(val)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      if (val.trim()) {
+        setParams({ q: val.trim() })
+      } else {
+        setParams({})
+      }
+    }, 300)
+  }
+
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Search results</h1>
-      <p className="text-sm text-stone-500">Query: {q || '(empty)'}</p>
-      {error && <p className="text-red-700">{error}</p>}
-      {hits === null && <p className="text-stone-500">Searching…</p>}
-      {hits && hits.length === 0 && q && (
-        <p className="text-stone-500">No matches.</p>
-      )}
-      <ul className="space-y-3">
-        {hits?.map((h) => (
-          <li key={h.entry_id} className="rounded border border-stone-200 bg-white p-4">
-            <Link to={`/entries/${h.entry_id}`} className="block">
-              <div className="text-xs text-stone-500">
-                similarity {h.similarity.toFixed(3)}
+    <>
+      <div className="page-head">
+        <div className="page-eye">
+          <span className="glyph">◈</span> Search
+        </div>
+        <h1 className="page-title">
+          Find by <em>feeling</em>, not just date.
+        </h1>
+        <p className="page-sub">
+          Semantic search over your entry summaries. Try phrases — &quot;the bracing feeling&quot;,
+          &quot;afternoon slump&quot;, &quot;something about my dad&quot;.
+        </p>
+      </div>
+
+      <div className="search-bar">
+        <SearchIcon />
+        <input
+          value={inputVal}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="What are you looking for?"
+          autoFocus
+        />
+        {hits !== null && (
+          <span className="hint">{hits.length} {hits.length === 1 ? 'match' : 'matches'}</span>
+        )}
+      </div>
+
+      {error && <p style={{ color: 'var(--rust)' }}>{error}</p>}
+      {hits === null && q && <p style={{ color: 'var(--ink-3)' }}>Searching…</p>}
+
+      {hits?.map((h) => {
+        const date = new Date(h.content.slice(0, 10) + 'T12:00')
+        const isValidDate = !isNaN(date.getTime())
+        return (
+          <Link
+            key={h.entry_id}
+            to={`/entries/${h.entry_id}`}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            <div className="search-result">
+              <div className="search-result-head">
+                <span className="search-result-date">
+                  {isValidDate
+                    ? date.toLocaleDateString('en-US', {
+                        weekday: 'short',
+                        month: 'short',
+                        day: 'numeric',
+                      })
+                    : 'Entry'}
+                </span>
+                <span className="search-result-score">
+                  {(h.similarity * 100).toFixed(0)}% match
+                </span>
               </div>
-              <div className="mt-1 line-clamp-2">{h.content}</div>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+              <p className="search-result-snippet">{h.content}</p>
+            </div>
+          </Link>
+        )
+      })}
+    </>
   )
 }

--- a/web/frontend/src/pages/Settings.tsx
+++ b/web/frontend/src/pages/Settings.tsx
@@ -1,6 +1,63 @@
 import { useEffect, useState } from 'react'
 import { api, type UserSettings } from '../api/client'
 
+function Toggle({
+  on,
+  onChange,
+  label,
+}: {
+  on: boolean
+  onChange: (val: boolean) => void
+  label: string
+}) {
+  return (
+    <label className={`toggle ${on ? 'on' : ''}`} onClick={() => onChange(!on)}>
+      <span className="toggle-track">
+        <span className="toggle-thumb" />
+      </span>
+      <span className="toggle-label">{label}</span>
+    </label>
+  )
+}
+
+function DownloadIcon() {
+  return (
+    <svg
+      width={14}
+      height={14}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <path d="M7 10l5 5 5-5" />
+      <path d="M12 15V3" />
+    </svg>
+  )
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      width={14}
+      height={14}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    </svg>
+  )
+}
+
 export function Settings() {
   const [settings, setSettings] = useState<UserSettings | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -49,56 +106,103 @@ export function Settings() {
     window.location.href = '/login'
   }
 
-  if (error) return <p className="text-red-700">{error}</p>
-  if (!settings) return <p className="text-stone-500">Loading…</p>
+  if (error) return <p style={{ color: 'var(--rust)' }}>{error}</p>
+  if (!settings) return <p style={{ color: 'var(--ink-3)' }}>Loading…</p>
 
   return (
-    <div className="space-y-8">
-      <h1 className="text-2xl font-semibold">Settings</h1>
+    <>
+      <div className="page-head">
+        <div className="page-eye">
+          <span className="glyph">◈</span> Settings
+        </div>
+        <h1 className="page-title">
+          Your <em>data</em>, your terms.
+        </h1>
+        <p className="page-sub">A few small toggles. Nothing else hidden behind submenus.</p>
+      </div>
 
-      <section className="space-y-3 rounded border border-stone-200 bg-white p-4">
-        <label className="block text-sm">
-          Timezone
+      <div className="set-section">
+        <div>
+          <div className="set-label">Timezone</div>
+          <p className="set-help">Used for the &quot;user-local date&quot; of each entry.</p>
+        </div>
+        <div className="set-control">
           <input
             type="text"
             value={settings.timezone ?? ''}
             onChange={(e) => setSettings({ ...settings, timezone: e.target.value })}
             onBlur={(e) => void save({ timezone: e.target.value })}
             placeholder="America/New_York"
-            className="mt-1 block w-full rounded border border-stone-300 px-3 py-2"
           />
-        </label>
+          {saving && (
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                color: 'var(--ink-3)',
+              }}
+            >
+              Saving…
+            </span>
+          )}
+        </div>
+      </div>
 
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={settings.transcript_enabled}
-            onChange={(e) =>
-              void save({ transcript_enabled: e.target.checked })
+      <div className="set-section">
+        <div>
+          <div className="set-label">Save transcripts</div>
+          <p className="set-help">
+            Stores the full conversation alongside the summary.
+          </p>
+        </div>
+        <div className="set-control">
+          <Toggle
+            on={settings.transcript_enabled}
+            onChange={(val) => void save({ transcript_enabled: val })}
+            label={
+              settings.transcript_enabled
+                ? 'On — summary + transcript'
+                : 'Off — summary only'
             }
           />
-          Save full transcript with each entry
-        </label>
-        {saving && <p className="text-xs text-stone-500">Saving…</p>}
-      </section>
+        </div>
+      </div>
 
-      <section className="space-y-3 rounded border border-stone-200 bg-white p-4">
-        <h2 className="font-semibold">Your data</h2>
-        <button
-          type="button"
-          onClick={() => void exportData()}
-          className="rounded bg-stone-900 px-4 py-2 text-white hover:bg-stone-800"
-        >
-          Export all data
-        </button>
-        <button
-          type="button"
-          onClick={() => void deleteAccount()}
-          className="ml-3 rounded border border-red-700 px-4 py-2 text-red-700 hover:bg-red-50"
-        >
-          Delete account
-        </button>
-      </section>
-    </div>
+      <div className="set-section">
+        <div>
+          <div className="set-label">Export everything</div>
+          <p className="set-help">
+            A JSON dump of every entry, pattern, and occurrence. Yours to take.
+          </p>
+        </div>
+        <div className="set-control">
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => void exportData()}
+          >
+            <DownloadIcon /> Export as JSON
+          </button>
+        </div>
+      </div>
+
+      <div className="set-section">
+        <div>
+          <div className="set-label">Delete account</div>
+          <p className="set-help">
+            Hard delete, cascading across all tables.
+          </p>
+        </div>
+        <div className="set-control">
+          <button
+            type="button"
+            className="btn btn-danger"
+            onClick={() => void deleteAccount()}
+          >
+            <TrashIcon /> Delete everything
+          </button>
+        </div>
+      </div>
+    </>
   )
 }

--- a/web/frontend/src/pages/__tests__/Home.test.tsx
+++ b/web/frontend/src/pages/__tests__/Home.test.tsx
@@ -11,14 +11,14 @@ vi.mock('../../api/client', () => ({
 import { Home } from '../Home'
 
 describe('Home', () => {
-  it('renders the recent-entries heading', async () => {
+  it('renders the journal library heading', async () => {
     render(
       <MemoryRouter>
         <Home />
       </MemoryRouter>,
     )
     expect(
-      screen.getByRole('heading', { name: /recent/i }),
+      screen.getByRole('heading', { name: /library/i }),
     ).toBeInTheDocument()
     await waitFor(() =>
       expect(screen.getByText(/no entries yet/i)).toBeInTheDocument(),


### PR DESCRIPTION
## Summary

- Replaces `@import "tailwindcss"` with the full design token layer (CSS variables for colors, type, spacing, radii, shadows, motion) from `colors_and_type.css`, `app.css`, and `site.css` — all inlined into `index.css`
- New `src/components/Brand.tsx` — `KindredMark` (two interlocking rings SVG) and `KindredWordmark` components, TypeScript-typed, no `window` assignments
- Layout replaced: top-nav → sticky sidebar with brand, search box, Library nav (Entries, Patterns, Search), Account nav (Connect, Settings), user footer with avatar initial + sign-out
- App routes moved to `/app/*` prefix; `/` now serves the public landing page
- All app pages restyled with design system classes: Home (entries list with month grouping), EntryDetail (occ cards + transcript toggle), Patterns (pat-list), PatternDetail (typical quadrants + timeline), Search (search-bar + results), Settings (set-section grid + Toggle component), Connect (step cards), McpAuth (moss/rust loading/error states), Login (centered card with KindredWordmark)
- New `src/pages/Landing.tsx` — full public landing page with Nav, Hero (with animated orbit + peeking entry cards), HowItWorks (3 steps), Conversation (auto-playing animated demo), PatternsSection (HCB bun), Privacy (4-column grid), EndCap + Footer
- SVG assets (illustration-orbit, illustration-plaque, logo-mark, texture-stars) copied to `public/`
- `tsc --noEmit` passes clean

## Test plan

- [ ] Visit `/` — landing page renders with fonts, animations, orbit illustration
- [ ] Click "Add to Claude" → redirects to `/app` (login if not authenticated)
- [ ] Sign in via Google → lands on `/app` with sidebar visible
- [ ] Sidebar active state highlights current route
- [ ] Sidebar search box click → navigates to `/app/search`
- [ ] Home page: entries load with month groupings and date column
- [ ] Entry detail: occ cards and transcript toggle work
- [ ] Patterns list and detail pages render correctly
- [ ] Search page: debounced input updates URL and fetches results
- [ ] Settings: Toggle component saves transcript_enabled; timezone input saves on blur
- [ ] Connect page: mint token flow works; copy buttons function
- [ ] McpAuth: loading state renders with bouncing dots; error state uses rust color
- [ ] Login page: KindredWordmark centered, Google button redirects to `/app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)