### PR TITLE
Add /privacy page and one-time crisis disclaimer modal

### DIFF
--- a/web/backend/routes/settings.py
+++ b/web/backend/routes/settings.py
@@ -20,6 +20,7 @@ router = APIRouter(tags=["settings"])
 class SettingsPatch(BaseModel):
     timezone: str | None = None
     transcript_enabled: bool | None = None
+    crisis_disclaimer_acknowledged_at: str | None = None
 
 
 def _user_metadata(user_id: str) -> dict[str, Any]:
@@ -38,6 +39,9 @@ def get_settings(
     return {
         "timezone": meta.get("timezone"),
         "transcript_enabled": meta.get("transcript_enabled", True),
+        "crisis_disclaimer_acknowledged_at": meta.get(
+            "crisis_disclaimer_acknowledged_at"
+        ),
     }
 
 
@@ -51,12 +55,19 @@ def update_settings(
         current["timezone"] = patch.timezone
     if patch.transcript_enabled is not None:
         current["transcript_enabled"] = patch.transcript_enabled
+    if patch.crisis_disclaimer_acknowledged_at is not None:
+        current["crisis_disclaimer_acknowledged_at"] = (
+            patch.crisis_disclaimer_acknowledged_at
+        )
     db.service_client().auth.admin.update_user_by_id(
         user["user_id"], {"user_metadata": current}
     )
     return {
         "timezone": current.get("timezone"),
         "transcript_enabled": current.get("transcript_enabled", True),
+        "crisis_disclaimer_acknowledged_at": current.get(
+            "crisis_disclaimer_acknowledged_at"
+        ),
     }
 
 

--- a/web/backend/tests/test_routes.py
+++ b/web/backend/tests/test_routes.py
@@ -104,6 +104,43 @@ def test_export_data(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> Non
     assert body["entries"][0]["id"] == "e1"
 
 
+def test_settings_patch_accepts_crisis_ack(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    stored: dict[str, Any] = {"user_metadata": {}}
+
+    def _service_client() -> MagicMock:
+        sb = MagicMock()
+        admin = MagicMock()
+
+        def _get_user_by_id(_user_id: str) -> MagicMock:
+            res = MagicMock()
+            res.user = MagicMock()
+            res.user.user_metadata = stored["user_metadata"]
+            return res
+
+        def _update_user_by_id(_user_id: str, payload: dict[str, Any]) -> None:
+            stored["user_metadata"] = payload["user_metadata"]
+
+        admin.get_user_by_id.side_effect = _get_user_by_id
+        admin.update_user_by_id.side_effect = _update_user_by_id
+        sb.auth.admin = admin
+        return sb
+
+    monkeypatch.setattr(db, "service_client", _service_client)
+
+    res = client.patch(
+        "/settings",
+        json={"crisis_disclaimer_acknowledged_at": "2026-05-03T12:00:00Z"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["crisis_disclaimer_acknowledged_at"] == "2026-05-03T12:00:00Z"
+    assert stored["user_metadata"]["crisis_disclaimer_acknowledged_at"] == (
+        "2026-05-03T12:00:00Z"
+    )
+
+
 def test_mint_connector_token(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
     inserted: dict[str, Any] = {}
 

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -94,6 +94,7 @@ export type SearchHit = {
 export type UserSettings = {
   timezone: string | null
   transcript_enabled: boolean
+  crisis_disclaimer_acknowledged_at: string | null
 }
 
 export type ConnectorToken = {

--- a/web/frontend/src/components/CrisisDisclaimerModal.tsx
+++ b/web/frontend/src/components/CrisisDisclaimerModal.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import { api, type UserSettings } from '../api/client'
+
+export function CrisisDisclaimerModal() {
+  const [settings, setSettings] = useState<UserSettings | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    api
+      .get<UserSettings>('/settings')
+      .then(setSettings)
+      .catch(() => {
+        // Fail open: do not block the app on a settings outage.
+        setSettings(null)
+      })
+  }, [])
+
+  const acknowledge = async () => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const next = await api.patch<UserSettings>('/settings', {
+        crisis_disclaimer_acknowledged_at: new Date().toISOString(),
+      })
+      setSettings(next)
+      setDismissed(true)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (dismissed) return null
+  if (!settings) return null
+  if (settings.crisis_disclaimer_acknowledged_at) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="crisis-disclaimer-title"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1000,
+        background: 'rgba(28,26,24,0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 'var(--sp-5)',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 460,
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--r-xl)',
+          padding: 'var(--sp-7)',
+          boxShadow: 'var(--shadow-md)',
+        }}
+      >
+        <h2
+          id="crisis-disclaimer-title"
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 'var(--fs-h3)',
+            fontWeight: 400,
+            margin: '0 0 var(--sp-4)',
+          }}
+        >
+          Before you begin
+        </h2>
+        <p
+          style={{
+            color: 'var(--ink-2)',
+            fontSize: 'var(--fs-md)',
+            lineHeight: 1.6,
+            margin: '0 0 var(--sp-4)',
+          }}
+        >
+          Kindred is a journaling tool, not a crisis service. If you&apos;re in
+          immediate distress, please contact a crisis line or emergency services.
+        </p>
+        <p
+          style={{
+            color: 'var(--ink-2)',
+            fontSize: 'var(--fs-sm)',
+            lineHeight: 1.6,
+            margin: '0 0 var(--sp-6)',
+          }}
+        >
+          In the UK, you can call Samaritans free at 116 123 (24/7), or visit{' '}
+          <a
+            href="https://www.samaritans.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            samaritans.org
+          </a>
+          . Resources vary by country.
+        </p>
+
+        {error && (
+          <p
+            style={{
+              color: 'var(--rust)',
+              fontSize: 13,
+              margin: '0 0 var(--sp-3)',
+            }}
+          >
+            {error}
+          </p>
+        )}
+
+        <button
+          type="button"
+          className="btn btn-primary btn-lg"
+          autoFocus
+          disabled={submitting}
+          onClick={() => void acknowledge()}
+          style={{ width: '100%', justifyContent: 'center' }}
+        >
+          {submitting ? 'Saving…' : 'I understand'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/frontend/src/components/Layout.tsx
+++ b/web/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { Link, Navigate, Outlet, useLocation, useNavigate } from 'react-router'
 import { useAuth } from '../store/auth'
 import { supabase } from '../lib/supabase'
 import { KindredMark } from './Brand'
+import { CrisisDisclaimerModal } from './CrisisDisclaimerModal'
 
 type IconName = 'book' | 'layers' | 'search' | 'settings' | 'plug'
 
@@ -162,6 +163,7 @@ export function Layout() {
 
       <main className="main">
         <Outlet />
+        <CrisisDisclaimerModal />
       </main>
     </div>
   )

--- a/web/frontend/src/components/__tests__/CrisisDisclaimerModal.test.tsx
+++ b/web/frontend/src/components/__tests__/CrisisDisclaimerModal.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+
+vi.mock('../../api/client', () => ({
+  api: {
+    get: vi.fn(),
+    patch: vi.fn(),
+  },
+}))
+
+import { api } from '../../api/client'
+import { CrisisDisclaimerModal } from '../CrisisDisclaimerModal'
+
+describe('CrisisDisclaimerModal', () => {
+  it('shows modal when ack timestamp is null', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      timezone: null,
+      transcript_enabled: true,
+      crisis_disclaimer_acknowledged_at: null,
+    })
+
+    render(<CrisisDisclaimerModal />)
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Kindred is a journaling tool/i),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.getAllByText(/Samaritans/i).length).toBeGreaterThan(0)
+  })
+
+  it('hides modal when ack timestamp is set', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      timezone: null,
+      transcript_enabled: true,
+      crisis_disclaimer_acknowledged_at: '2026-05-03T00:00:00Z',
+    })
+
+    render(<CrisisDisclaimerModal />)
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled())
+    expect(
+      screen.queryByText(/Kindred is a journaling tool/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('persists ack on button click and hides modal', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      timezone: null,
+      transcript_enabled: true,
+      crisis_disclaimer_acknowledged_at: null,
+    })
+    vi.mocked(api.patch).mockResolvedValueOnce({
+      timezone: null,
+      transcript_enabled: true,
+      crisis_disclaimer_acknowledged_at: '2026-05-03T12:00:00Z',
+    })
+
+    render(<CrisisDisclaimerModal />)
+
+    const button = await screen.findByRole('button', { name: /i understand/i })
+    fireEvent.click(button)
+
+    await waitFor(() =>
+      expect(api.patch).toHaveBeenCalledWith('/settings', {
+        crisis_disclaimer_acknowledged_at: expect.stringMatching(
+          /^\d{4}-\d{2}-\d{2}T/,
+        ),
+      }),
+    )
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Kindred is a journaling tool/i),
+      ).not.toBeInTheDocument(),
+    )
+  })
+})

--- a/web/frontend/src/main.tsx
+++ b/web/frontend/src/main.tsx
@@ -25,6 +25,7 @@ import { Search } from './pages/Search'
 import { Settings } from './pages/Settings'
 import { Connect } from './pages/Connect'
 import { McpAuth } from './pages/McpAuth'
+import { Privacy } from './pages/Privacy'
 
 const router = createBrowserRouter([
   {
@@ -35,6 +36,7 @@ const router = createBrowserRouter([
       { path: '/', element: <Landing /> },
       { path: '/login', element: <Login /> },
       { path: '/mcp-auth', element: <McpAuth /> },
+      { path: '/privacy', element: <Privacy /> },
       // Authenticated app routes
       {
         path: '/app',

--- a/web/frontend/src/pages/Landing.tsx
+++ b/web/frontend/src/pages/Landing.tsx
@@ -21,7 +21,7 @@ function Nav() {
         <a href="#how" className="nav-link">How it works</a>
         <a href="#demo" className="nav-link">Demo</a>
         <a href="#patterns" className="nav-link">Patterns</a>
-        <a href="#privacy" className="nav-link">Privacy</a>
+        <Link to="/privacy" className="nav-link">Privacy</Link>
       </div>
       <div className="nav-cta">
         {session
@@ -680,6 +680,11 @@ function Privacy() {
             </p>
           </div>
         </div>
+        <div style={{ marginTop: 'var(--sp-5)' }}>
+          <Link to="/privacy" className="nav-link">
+            Read the full policy →
+          </Link>
+        </div>
       </div>
     </section>
   )
@@ -741,7 +746,7 @@ function EndCap() {
           InterstellarAI
         </div>
         <div>
-          <a href="#privacy">Privacy</a>
+          <Link to="/privacy">Privacy</Link>
           <a href="#">Terms</a>
           <a href="#">Field notes</a>
         </div>

--- a/web/frontend/src/pages/Privacy.tsx
+++ b/web/frontend/src/pages/Privacy.tsx
@@ -1,0 +1,291 @@
+import { Link } from 'react-router'
+import { KindredMark } from '../components/Brand'
+
+const LAST_UPDATED = '2026-05-03'
+
+function Section({
+  eyebrow,
+  title,
+  children,
+}: {
+  eyebrow: string
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section style={{ marginBottom: 'var(--sp-7)' }}>
+      <div className="eyebrow" style={{ marginBottom: 'var(--sp-2)' }}>
+        <span className="glyph">✶</span> {eyebrow}
+      </div>
+      <h2
+        style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: 'var(--fs-h3)',
+          fontWeight: 400,
+          margin: '0 0 var(--sp-3)',
+        }}
+      >
+        {title}
+      </h2>
+      <div
+        style={{
+          color: 'var(--ink-2)',
+          fontSize: 'var(--fs-md)',
+          lineHeight: 1.65,
+        }}
+      >
+        {children}
+      </div>
+    </section>
+  )
+}
+
+export function Privacy() {
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--paper)' }}>
+      <nav className="nav">
+        <Link to="/" className="nav-brand" style={{ textDecoration: 'none' }}>
+          <KindredMark size={26} />
+          <span className="wm">
+            <em>Kindred</em>
+            <span className="dot">.</span>
+          </span>
+        </Link>
+        <div className="nav-cta">
+          <Link to="/" className="nav-link">
+            Back to home
+          </Link>
+        </div>
+      </nav>
+
+      <main className="wrap" style={{ padding: 'var(--sp-7) var(--sp-5)' }}>
+        <div style={{ maxWidth: '68ch', margin: '0 auto' }}>
+          <header style={{ marginBottom: 'var(--sp-7)' }}>
+            <div className="eyebrow" style={{ marginBottom: 'var(--sp-3)' }}>
+              <span className="glyph">✶</span> Privacy
+            </div>
+            <h1
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 'var(--fs-h1)',
+                fontWeight: 400,
+                lineHeight: 1.1,
+                margin: '0 0 var(--sp-3)',
+              }}
+            >
+              Your <em>journal</em>. Not our dataset.
+            </h1>
+            <p
+              style={{
+                color: 'var(--ink-3)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 13,
+                letterSpacing: '0.04em',
+                margin: 0,
+              }}
+            >
+              Last updated: {LAST_UPDATED}
+            </p>
+          </header>
+
+          <Section eyebrow="01" title="Who we are">
+            <p>
+              Kindred is operated by InterstellarAI. For privacy questions or to
+              exercise your rights under UK/EU GDPR, contact us at{' '}
+              <a href="mailto:privacy@interstellarai.net">
+                privacy@interstellarai.net
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section eyebrow="02" title="What we collect">
+            <p>We store only what we need to run the journal:</p>
+            <ul>
+              <li>
+                <strong>Journal entries</strong> — the words you write to the AI
+                during a session, plus the AI&apos;s replies.
+              </li>
+              <li>
+                <strong>Pattern names and occurrences</strong> — the names you
+                give to recurring themes and the four-quadrant breakdowns you
+                log against them.
+              </li>
+              <li>
+                <strong>Optional full transcripts</strong> — only when the
+                &ldquo;Save transcripts&rdquo; toggle in{' '}
+                <code>/app/settings</code> is on.
+              </li>
+              <li>
+                <strong>Authentication info</strong> — your email address, via
+                Google OAuth.
+              </li>
+              <li>
+                <strong>Connector tokens</strong> — random opaque strings used
+                by the Claude.ai MCP connector to identify your account.
+              </li>
+            </ul>
+          </Section>
+
+          <Section
+            eyebrow="03"
+            title="Lawful basis for processing (UK GDPR Art. 6)"
+          >
+            <p>
+              <strong>Contract (Art. 6(1)(b))</strong> — processing your entries,
+              patterns, and account data is necessary to provide the journaling
+              service you signed up for.
+            </p>
+            <p>
+              <strong>Consent (Art. 6(1)(a))</strong> — for the optional
+              transcript-saving toggle, which you can turn off at any time in{' '}
+              <code>/app/settings</code>.
+            </p>
+          </Section>
+
+          <Section eyebrow="04" title="Recipients and sub-processors">
+            <p>
+              <strong>Supabase</strong> — database hosting and authentication.
+              See{' '}
+              <a
+                href="https://supabase.com/legal/dpa"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                supabase.com/legal/dpa
+              </a>{' '}
+              and{' '}
+              <a
+                href="https://supabase.com/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                supabase.com/privacy
+              </a>
+              . Supabase&apos;s own infrastructure providers (AWS, Google
+              Cloud, Cloudflare, and others) handle the underlying layers; their
+              canonical, current list lives at the Supabase DPA link above
+              rather than being duplicated here.
+            </p>
+            <p>
+              <strong>Sentry</strong> — error monitoring. We do not send journal
+              content to Sentry; only error stack traces and request metadata.
+            </p>
+            <p>
+              <strong>Your chosen AI provider</strong> (e.g. Anthropic Claude,
+              OpenAI, etc.) — your conversation is sent to whichever provider
+              you have connected via the Claude.ai connector you set up.
+              Kindred does not control that provider&apos;s data retention or
+              training behaviour. Review your AI provider&apos;s privacy
+              settings directly.
+            </p>
+          </Section>
+
+          <Section eyebrow="05" title="An honest note on access and encryption">
+            <p>
+              Kindred staff with database access could in principle read your
+              entries. We commit not to do so except as required to operate the
+              service or by law. Data is encrypted in transit (TLS) and at rest
+              at the disk level via Supabase. This is{' '}
+              <strong>not end-to-end encryption</strong> — the service and your
+              chosen AI provider need to read your entries to function.
+            </p>
+          </Section>
+
+          <Section eyebrow="06" title="No model training by Kindred">
+            <p>
+              We do not train any model on your data, and we do not license your
+              data to third parties for training. If we add embeddings later
+              (for example, to power <code>/app/search</code>), the embedding
+              provider will be named in this section.
+            </p>
+          </Section>
+
+          <Section eyebrow="07" title="International transfers">
+            <p>
+              Supabase infrastructure may process data outside the UK and EEA.
+              The{' '}
+              <a
+                href="https://supabase.com/legal/dpa"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Supabase Data Processing Addendum
+              </a>{' '}
+              covers Standard Contractual Clauses (SCCs) for these transfers.
+            </p>
+          </Section>
+
+          <Section eyebrow="08" title="Retention">
+            <p>
+              Entries, patterns, and occurrences are retained until you delete
+              them or your account. Use{' '}
+              <code>/app/settings → Delete account</code> for a hard cascading
+              delete across every table that references your user ID.
+            </p>
+          </Section>
+
+          <Section eyebrow="09" title="Your rights (UK/EU GDPR)">
+            <p>
+              You have the right to: access, rectification, erasure,
+              restriction, portability, objection, and (where consent is the
+              basis) withdrawal of consent. You can export everything via{' '}
+              <code>/app/settings → Export as JSON</code>, and exercise the
+              other rights by emailing{' '}
+              <a href="mailto:privacy@interstellarai.net">
+                privacy@interstellarai.net
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section eyebrow="10" title="Right to complain">
+            <p>
+              If you believe we&apos;ve mishandled your data, you can complain
+              to the UK Information Commissioner&apos;s Office at{' '}
+              <a
+                href="https://ico.org.uk/make-a-complaint/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ico.org.uk/make-a-complaint
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section eyebrow="11" title="Automated decision-making">
+            <p>
+              Kindred performs no automated decision-making with legal or
+              similarly significant effects on you.
+            </p>
+          </Section>
+
+          <Section eyebrow="12" title="Crisis services">
+            <p>
+              Kindred is a journaling tool, not a crisis service. If you&apos;re
+              in immediate distress, contact a crisis line or emergency
+              services. In the UK, Samaritans is free at 116 123 (24/7) or at{' '}
+              <a
+                href="https://www.samaritans.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                samaritans.org
+              </a>
+              . Resources vary by country.
+            </p>
+          </Section>
+
+          <Section eyebrow="13" title="Changes to this policy">
+            <p>
+              We will update this page when our practices change and bump the
+              &ldquo;Last updated&rdquo; date above. Material changes will be
+              communicated in-app.
+            </p>
+          </Section>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/web/frontend/src/pages/__tests__/Privacy.test.tsx
+++ b/web/frontend/src/pages/__tests__/Privacy.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+
+import { Privacy } from '../Privacy'
+
+describe('Privacy', () => {
+  it('renders the required GDPR section labels', () => {
+    render(
+      <MemoryRouter>
+        <Privacy />
+      </MemoryRouter>,
+    )
+    expect(
+      screen.getByRole('heading', { level: 1, name: /journal/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/last updated:/i)).toBeInTheDocument()
+    expect(screen.getByText(/lawful basis/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/Supabase/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Samaritans/i).length).toBeGreaterThan(0)
+    expect(screen.getByText(/ico\.org\.uk/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Ships a UK-GDPR-Art.-13-compliant `/privacy` page and a one-time crisis-content disclaimer modal shown on first authenticated entry to `/app/*`. Together these unblock opening Kindred to other users by (a) honestly disclosing data handling, sub-processors, and the user-chosen AI provider relationship, and (b) making explicit that Kindred is a journaling tool, not a crisis service.

Fixes #45. Covers the in-scope crisis-disclaimer portion of #46.

## Changes

**Frontend (`web/frontend`)**
- `pages/Privacy.tsx` — NEW public page structured around UK GDPR Art. 13: who we are, what we collect, lawful basis (Contract + Consent), recipients/sub-processors (Supabase + transitive list linked, not duplicated), honest staff-access statement, no-model-training commitment, international transfers, retention, GDPR rights, ICO complaint route, automated decision-making note, crisis services note, changelog.
- `main.tsx` — registers `/privacy` as a public route alongside `/login` and `/mcp-auth` (NOT under `/app`, so it's reachable while logged out and indexable).
- `pages/Landing.tsx` — switches nav (line ~24) and footer (line ~744) `<a href="#privacy">` to `<Link to="/privacy">`; preserves the in-page marketing section + `id="privacy"` for older deep-links and adds a "Read the full policy →" link funneling into the legal page.
- `components/CrisisDisclaimerModal.tsx` — NEW. On mount, fetches `/settings`. If `crisis_disclaimer_acknowledged_at` is null, renders a fixed-overlay card (not dismissible by backdrop or Esc) with the verbatim disclaimer copy from #45/#46 and a Samaritans link (`116 123`, `samaritans.org`, `target="_blank" rel="noopener noreferrer"`). Single "I understand" button PATCHes the timestamp; in-flight disabled; on error keeps modal open with inline error so user can retry; fail-open if `GET /settings` errors.
- `components/Layout.tsx` — mounts `<CrisisDisclaimerModal />` inside the auth-gated branch (after the `Navigate to="/login"` guard) so unauthenticated visitors don't trigger 401s.
- `api/client.ts` — extends `UserSettings` with `crisis_disclaimer_acknowledged_at: string | null` (snake_case, matches backend JSON shape).

**Backend (`web/backend`)**
- `routes/settings.py` — extends `SettingsPatch` with `crisis_disclaimer_acknowledged_at: str | None = None`; adds the field to the GET return dict, the PATCH merge branch, and the PATCH return dict. No DB migration needed — `auth.users.user_metadata` is JSONB and the existing route already passes arbitrary keys through.

**Tests**
- `frontend/src/pages/__tests__/Privacy.test.tsx` — NEW smoke test asserting the GDPR section labels render (lawful basis, Supabase, Samaritans, ICO, "Last updated").
- `frontend/src/components/__tests__/CrisisDisclaimerModal.test.tsx` — NEW. Three tests: (1) shows when ack null, (2) hides when ack set, (3) clicking I-understand persists timestamp via PATCH and hides modal.
- `backend/tests/test_routes.py` — adds `test_settings_patch_accepts_crisis_ack` round-tripping the new field.

10 files changed, ~584 insertions, 2 deletions.

## Validation

All checks passed on the first run, no fixes required.

| Check | Command | Result |
|-------|---------|--------|
| Frontend type check | `npm run typecheck` (`tsc --noEmit`) | ✅ exit 0 |
| Frontend lint | `npm run lint` (`eslint .`) | ✅ 0 errors, 0 warnings |
| Frontend tests | `npm test -- --run` (`vitest --run`) | ✅ 5/5 passed across 3 files (Home, CrisisDisclaimerModal, Privacy) in 900ms |
| Frontend build | `npm run build` (`tsc -b && vite build`) | ✅ 327 modules, 1.86s. Pre-existing >500kB chunk warning unchanged. |
| Backend compile | `python -m compileall routes/ tests/` | ✅ clean |
| Backend tests | `pytest tests/ -v` | ✅ 12/12 passed in 1.19s (including new `test_settings_patch_accepts_crisis_ack`) |

Format/format:check skipped — Prettier is not wired up in this project (no `format` script in `package.json`).

## Acceptance criteria (from #45 and in-scope #46)

- [x] Privacy policy live at `/privacy` (new public route).
- [x] Linked from footer; in-page Landing section retains `id="privacy"` plus a "Read full policy →" link.
- [x] Reviewed for UK/EU GDPR compliance — page structured around Art. 13's required content with lawful basis explicitly stated (Contract for the journaling service; Consent for the optional transcript-saving toggle). ICO complaint route linked.
- [x] Single clear crisis disclaimer during first-time setup, shown once before connecting an AI assistant, not shown again after acknowledgement; flag stored in `user_metadata.crisis_disclaimer_acknowledged_at`.
- [x] Wording matches the issue verbatim: "Kindred is a journaling tool, not a crisis service. If you're in immediate distress, please contact a crisis line or emergency services."
- [x] Links to Samaritans (`116 123`, `samaritans.org`) with a "resources vary by country" note.

## Deviations from plan

- **Test assertions widened** from `screen.getByText(/Samaritans|Supabase/i)` to `screen.getAllByText(...).length > 0` because the Privacy page mentions Supabase three times and the modal mentions Samaritans both as link text and inline copy; `getByText` throws on multiple matches. Same semantic intent, less brittle to copy edits.
- **Contact email** uses placeholder `privacy@interstellarai.net` (consistent with the "InterstellarAI" branding already in the Landing footer). Flagged for human review before public launch — no alternative was provided in the artifacts.

## Notes for reviewer

- Modal **fails open**: if `GET /settings` errors, no modal renders. Better to risk re-showing next session than to lock users out of the app.
- Modal mount lives **inside** the `if (!session) return <Navigate />` guard in `Layout`, so unauthenticated visitors don't trigger a 401-causing settings fetch.
- The Landing in-page `Privacy` section (`id="privacy"`) was deliberately preserved so older `/#privacy` deep-links still scroll to the marketing summary; the summary now funnels into `/privacy` via a "Read the full policy →" link.
- Tests do not pin the literal "Last updated" date — only the label — so the date in `Privacy.tsx` can be bumped without breaking tests.
- The branch is also 1 commit behind `origin/main` (`fc2a9e5 Style: design tokens & base typography (#21) (#48)`) which touches a separate area; merging `main` in is up to the reviewer's preference.

## Test plan

- [ ] Visit `/privacy` while logged out → page renders with all GDPR sections; external links (Supabase DPA, ICO, Samaritans) open in new tab with `rel="noopener noreferrer"`.
- [ ] Sign in as a fresh user (or clear `user_metadata.crisis_disclaimer_acknowledged_at` in Supabase for an existing user) → first `/app` load shows the modal blocking Home.
- [ ] Click "I understand" → modal closes; hard-refresh → modal does NOT reappear.
- [ ] Navigate to `/app/connect` after acking → no modal, connect flow works.
- [ ] Click footer "Privacy" from `/` → URL changes to `/privacy` (no in-page scroll), page renders.
- [ ] Visit `/#privacy` directly → scrolls to the Landing marketing section (deep-link still works).
- [ ] Simulate `GET /settings` failure → no modal renders, app remains usable.
- [ ] Simulate `PATCH /settings` failure on ack click → inline error appears, modal stays open, button re-enabled, retry succeeds.