### PR TITLE
Eliminate service_role usage from request handlers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,28 @@
-# Supabase
+# ----------------------------------------------------------------------------
+# Supabase keys — used by different surfaces, with very different blast radius
+# ----------------------------------------------------------------------------
+# Used by: web frontend, web backend, MCP server, scripts/, supabase CLI.
+# Safe to expose in browser bundles. Honours Postgres Row Level Security on
+# every query, scoped via the caller's bearer JWT (Authorization header).
 SUPABASE_URL=
+
+# Used by: web frontend, web backend, MCP server. Safe to expose in browser
+# bundles. RLS is enforced — without a user JWT, queries see anonymous-only
+# data (none of our tables grant select to `anon`).
 SUPABASE_ANON_KEY=
+
+# Used by: scripts/, supabase/ migrations, supabase CLI ONLY.
+# DO NOT use from request-handling code (mcp/, web/backend/). This key carries
+# the Postgres BYPASSRLS attribute — any query made with it skips Row Level
+# Security and can return cross-user data. The grep gate in scripts/gates.sh
+# fails CI on reintroduction. Note: Supabase is transitioning this to
+# `sb_secret_*` naming; the env-var name will change in a future PR.
 SUPABASE_SERVICE_ROLE_KEY=
-# HS256 path. Find this at Supabase Dashboard → Settings → API → JWT Secret.
+
+# Used by: MCP server (to mint short-lived per-request user JWTs that
+# PostgREST validates as `role/aud=authenticated`). Find this at Supabase
+# Dashboard → Settings → API → JWT Secret. Treat like a service-role key:
+# leakage = ability to mint an `authenticated` JWT for any user_id.
 SUPABASE_JWT_SECRET=
 
 # Requesty (embeddings)

--- a/mcp/db.py
+++ b/mcp/db.py
@@ -1,48 +1,92 @@
-"""Service-role Supabase client + every read/write helper used by tools.
+"""Anon-key Supabase clients + every read/write helper used by tools.
 
-The service-role key bypasses RLS, so every helper here must filter explicitly
-by ``user_id``. Tool code must never construct queries inline — go through
-this module so the user-scoping discipline is centralised.
+The MCP server has no incoming user JWT (tools are invoked with a connector
+token or an OAuth code, neither of which carry Supabase claims), so we mint a
+short-lived HS256 JWT signed with ``SUPABASE_JWT_SECRET`` per call and attach
+it via ``client.postgrest.auth(...)``. RLS then enforces ownership in
+Postgres; the defensive ``eq("user_id", user_id)`` filters stay as
+belt-and-braces.
+
+The only path that doesn't have a user_id at hand is the connector-token
+verifier, which calls a security-definer RPC under the anon role.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from functools import lru_cache
 from typing import Any
 from uuid import UUID
 
+import jwt
 from supabase import Client, create_client
 
 from settings import settings
 
+_USER_JWT_TTL = timedelta(minutes=5)
+
+
+def _supabase_user_jwt(user_id: str) -> str:
+    """Mint a short-lived HS256 JWT PostgREST will accept as ``authenticated``.
+
+    Both ``role`` and ``aud`` must equal ``"authenticated"`` or PostgREST
+    rejects the request with a 401 — so callers see a clear failure rather
+    than silently empty results. The TTL is short because we mint per call;
+    do NOT cache across users.
+    """
+    if not settings.supabase_jwt_secret:
+        raise RuntimeError("SUPABASE_JWT_SECRET is not configured")
+    now = datetime.now(UTC)
+    return jwt.encode(
+        {
+            "sub": user_id,
+            "role": "authenticated",
+            "aud": "authenticated",
+            "iat": int(now.timestamp()),
+            "exp": int((now + _USER_JWT_TTL).timestamp()),
+        },
+        settings.supabase_jwt_secret,
+        algorithm="HS256",
+    )
+
+
+def user_client(user_id: str) -> Client:
+    """Anon-key client with a freshly-minted user JWT attached.
+
+    Constructed per call — never cached, because caching across users would
+    re-introduce the cross-user leak the refactor is designed to prevent.
+    """
+    client = create_client(settings.supabase_url, settings.supabase_anon_key)
+    client.postgrest.auth(_supabase_user_jwt(user_id))
+    return client
+
 
 @lru_cache(maxsize=1)
-def service_client() -> Client:
-    return create_client(settings.supabase_url, settings.supabase_service_role_key)
+def anon_client() -> Client:
+    """Anon-key client with no user JWT — only safe for security-definer RPCs."""
+    return create_client(settings.supabase_url, settings.supabase_anon_key)
 
 
-def _table(name: str) -> Any:
-    return service_client().table(name)
+def _table(user_id: str, name: str) -> Any:
+    """Untyped query builder for a user-scoped client — typing escape hatch."""
+    return user_client(user_id).table(name)
 
 
 # ---------------------------------------------------------------------------
 # connector tokens (used by the auth verifier)
 # ---------------------------------------------------------------------------
 def lookup_connector_token(token: str) -> dict[str, Any] | None:
-    res = _table("connector_tokens").select("*").eq("token", token).limit(1).execute()
-    rows = res.data or []
-    return rows[0] if rows else None
+    """Resolve a bearer token to its user via the security-definer RPC.
 
-
-def insert_connector_token(user_id: str, token: str) -> dict[str, Any]:
-    res = (
-        _table("connector_tokens")
-        .insert({"user_id": user_id, "token": token})
-        .execute()
-    )
-    rows = res.data or []
-    return rows[0] if rows else {}
+    The RPC returns the matching ``user_id`` (uuid) directly, or ``NULL``
+    when the token is unknown. We wrap it in the legacy ``{user_id, token}``
+    dict shape so ``mcp/auth.py`` callers don't change.
+    """
+    res = anon_client().rpc("lookup_connector_token", {"p_token": token}).execute()
+    user_id = res.data
+    if not user_id:
+        return None
+    return {"user_id": str(user_id), "token": token}
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +106,7 @@ def insert_entry(
         "mood": mood,
         "transcript": transcript,
     }
-    res = _table("entries").insert(payload).execute()
+    res = _table(user_id, "entries").insert(payload).execute()
     rows = res.data or []
     if not rows:
         raise RuntimeError("insert_entry returned no row")
@@ -71,7 +115,7 @@ def insert_entry(
 
 def get_entry_by_id(user_id: str, entry_id: str) -> dict[str, Any] | None:
     res = (
-        _table("entries")
+        _table(user_id, "entries")
         .select("*")
         .eq("user_id", user_id)
         .eq("id", entry_id)
@@ -84,7 +128,7 @@ def get_entry_by_id(user_id: str, entry_id: str) -> dict[str, Any] | None:
 
 def get_entry_by_date(user_id: str, date: str) -> dict[str, Any] | None:
     res = (
-        _table("entries")
+        _table(user_id, "entries")
         .select("*")
         .eq("user_id", user_id)
         .eq("date", date)
@@ -98,7 +142,7 @@ def get_entry_by_date(user_id: str, date: str) -> dict[str, Any] | None:
 
 def list_recent_entries(user_id: str, limit: int = 10) -> list[dict[str, Any]]:
     res = (
-        _table("entries")
+        _table(user_id, "entries")
         .select("id,date,summary,mood,created_at")
         .eq("user_id", user_id)
         .order("date", desc=True)
@@ -112,7 +156,7 @@ def list_recent_entries(user_id: str, limit: int = 10) -> list[dict[str, Any]]:
 # embeddings + semantic search
 # ---------------------------------------------------------------------------
 def insert_embedding(user_id: str, entry_id: str, embedding: list[float], content: str) -> None:
-    _table("entry_embeddings").insert(
+    _table(user_id, "entry_embeddings").insert(
         {
             "entry_id": entry_id,
             "user_id": user_id,
@@ -125,27 +169,16 @@ def insert_embedding(user_id: str, entry_id: str, embedding: list[float], conten
 def match_entries(
     user_id: str, query_embedding: list[float], limit: int = 5
 ) -> list[dict[str, Any]]:
-    res = service_client().rpc(
-        "match_entries",
-        {"query_embedding": query_embedding, "match_count": limit},
-    ).execute()
-    raw_rows: Any = res.data or []
-    rows: list[dict[str, Any]] = list(raw_rows)
-    if not rows:
-        return rows
-    # Defensive re-filter: service-role bypasses RLS, so we cross-check
-    # ownership against entries.user_id before returning.
-    entry_ids = [r["entry_id"] for r in rows]
-    owned = (
-        _table("entries")
-        .select("id")
-        .eq("user_id", user_id)
-        .in_("id", entry_ids)
+    res = (
+        user_client(user_id)
+        .rpc(
+            "match_entries",
+            {"query_embedding": query_embedding, "match_count": limit},
+        )
         .execute()
     )
-    owned_rows: list[dict[str, Any]] = list(owned.data or [])
-    owned_ids = {r["id"] for r in owned_rows}
-    return [r for r in rows if r["entry_id"] in owned_ids]
+    raw: Any = res.data or []
+    return list(raw)
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +187,7 @@ def match_entries(
 def find_pattern_by_name(user_id: str, name: str) -> dict[str, Any] | None:
     # case-insensitive match; PostgREST `ilike` filter
     res = (
-        _table("patterns")
+        _table(user_id, "patterns")
         .select("*")
         .eq("user_id", user_id)
         .ilike("name", name)
@@ -166,7 +199,7 @@ def find_pattern_by_name(user_id: str, name: str) -> dict[str, Any] | None:
 
 
 def list_patterns(user_id: str, active_since: str | None = None) -> list[dict[str, Any]]:
-    q = _table("patterns").select("*").eq("user_id", user_id)
+    q = _table(user_id, "patterns").select("*").eq("user_id", user_id)
     if active_since is not None:
         q = q.gte("last_seen_at", active_since)
     res = q.order("last_seen_at", desc=True).execute()
@@ -179,7 +212,7 @@ def get_pattern(user_id: str, name_or_id: str) -> dict[str, Any] | None:
     except ValueError:
         return find_pattern_by_name(user_id, name_or_id)
     res = (
-        _table("patterns")
+        _table(user_id, "patterns")
         .select("*")
         .eq("user_id", user_id)
         .eq("id", name_or_id)
@@ -208,22 +241,28 @@ def insert_pattern(
         "typical_behaviors": typical_behaviors,
         "typical_sensations": typical_sensations,
     }
-    res = _table("patterns").insert(payload).execute()
+    res = _table(user_id, "patterns").insert(payload).execute()
     rows = res.data or []
     if not rows:
         raise RuntimeError("insert_pattern returned no row")
     return str(rows[0]["id"])
 
 
-def update_pattern_seen(pattern_id: str, last_seen_at: str | None = None) -> None:
+def update_pattern_seen(
+    user_id: str, pattern_id: str, last_seen_at: str | None = None
+) -> None:
     last_seen = last_seen_at or datetime.utcnow().isoformat()
     # Read-then-write because PostgREST doesn't support raw SQL increments.
     res = (
-        _table("patterns").select("occurrence_count").eq("id", pattern_id).limit(1).execute()
+        _table(user_id, "patterns")
+        .select("occurrence_count")
+        .eq("id", pattern_id)
+        .limit(1)
+        .execute()
     )
     rows = res.data or []
     current = int(rows[0]["occurrence_count"]) if rows else 0
-    _table("patterns").update(
+    _table(user_id, "patterns").update(
         {"last_seen_at": last_seen, "occurrence_count": current + 1}
     ).eq("id", pattern_id).execute()
 
@@ -257,7 +296,7 @@ def insert_occurrence(
         "trigger": trigger,
         "notes": notes,
     }
-    res = _table("pattern_occurrences").insert(payload).execute()
+    res = _table(user_id, "pattern_occurrences").insert(payload).execute()
     rows = res.data or []
     if not rows:
         raise RuntimeError("insert_occurrence returned no row")
@@ -268,7 +307,7 @@ def list_occurrences(
     user_id: str, pattern_id: str, since: str | None = None
 ) -> list[dict[str, Any]]:
     q = (
-        _table("pattern_occurrences")
+        _table(user_id, "pattern_occurrences")
         .select("*")
         .eq("user_id", user_id)
         .eq("pattern_id", pattern_id)
@@ -281,7 +320,7 @@ def list_occurrences(
 
 def list_occurrences_for_entry(user_id: str, entry_id: str) -> list[dict[str, Any]]:
     res = (
-        _table("pattern_occurrences")
+        _table(user_id, "pattern_occurrences")
         .select("*")
         .eq("user_id", user_id)
         .eq("entry_id", entry_id)
@@ -292,11 +331,11 @@ def list_occurrences_for_entry(user_id: str, entry_id: str) -> list[dict[str, An
 
 
 __all__ = [
+    "anon_client",
     "find_pattern_by_name",
     "get_entry_by_date",
     "get_entry_by_id",
     "get_pattern",
-    "insert_connector_token",
     "insert_embedding",
     "insert_entry",
     "insert_occurrence",
@@ -307,6 +346,6 @@ __all__ = [
     "list_recent_entries",
     "lookup_connector_token",
     "match_entries",
-    "service_client",
     "update_pattern_seen",
+    "user_client",
 ]

--- a/mcp/settings.py
+++ b/mcp/settings.py
@@ -5,7 +5,6 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore", case_sensitive=False)
 
     supabase_url: str = ""
-    supabase_service_role_key: str = ""
 
     requesty_api_key: str = ""
     requesty_base_url: str = "https://router.requesty.ai/v1"

--- a/mcp/tests/test_auth.py
+++ b/mcp/tests/test_auth.py
@@ -25,6 +25,29 @@ async def test_verify_token_unknown_returns_none(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
+async def test_lookup_connector_token_rpc_none_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anon RPC returning NULL → verifier returns None (no exception)."""
+
+    class _RpcResp:
+        data = None
+
+    class _RpcChain:
+        def execute(self) -> _RpcResp:
+            return _RpcResp()
+
+    class _Client:
+        def rpc(self, _name: str, _params: dict[str, Any]) -> _RpcChain:
+            return _RpcChain()
+
+    monkeypatch.setattr(db, "anon_client", lambda: _Client())
+    assert db.lookup_connector_token("missing") is None
+    verifier = ConnectorTokenVerifier()
+    assert await verifier.verify_token("missing") is None
+
+
+@pytest.mark.asyncio
 async def test_verify_token_known_returns_access_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/mcp/tests/test_db.py
+++ b/mcp/tests/test_db.py
@@ -1,0 +1,75 @@
+"""Tests for the per-request user JWT minted by ``db.user_client``.
+
+Without these, an ``aud`` or ``role`` typo silently breaks RLS — PostgREST
+returns empty data, not an error, and tools just go quiet.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+
+import db
+import settings as settings_module
+
+JWT_SECRET = "test-jwt-secret-needs-to-be-at-least-32-bytes-long"
+USER_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def _supabase_jwt_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_module.settings, "supabase_jwt_secret", JWT_SECRET)
+
+
+def test_user_client_jwt_signed_with_supabase_jwt_secret(
+    _supabase_jwt_secret: None,
+) -> None:
+    token = db._supabase_user_jwt(USER_ID)
+    payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"], audience="authenticated")
+    assert payload["sub"] == USER_ID
+
+
+def test_user_client_jwt_role_and_aud_are_authenticated(
+    _supabase_jwt_secret: None,
+) -> None:
+    """Both claims must be ``authenticated`` or PostgREST 401s the request."""
+    token = db._supabase_user_jwt(USER_ID)
+    payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"], audience="authenticated")
+    assert payload["role"] == "authenticated"
+    assert payload["aud"] == "authenticated"
+
+
+def test_user_client_jwt_short_ttl(_supabase_jwt_secret: None) -> None:
+    """5-minute TTL prevents long-lived JWT reuse across requests."""
+    before = int(datetime.now(UTC).timestamp())
+    token = db._supabase_user_jwt(USER_ID)
+    payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"], audience="authenticated")
+    ttl = payload["exp"] - before
+    assert 0 < ttl <= 5 * 60 + 5  # +5s tolerance for slow CI clocks
+
+
+def test_user_client_raises_when_secret_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_module.settings, "supabase_jwt_secret", "")
+    with pytest.raises(RuntimeError, match="SUPABASE_JWT_SECRET"):
+        db._supabase_user_jwt(USER_ID)
+
+
+def test_user_client_attaches_jwt_via_postgrest_auth(
+    _supabase_jwt_secret: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``user_client`` must call ``client.postgrest.auth(jwt)`` exactly once."""
+    fake_client = MagicMock()
+
+    def _fake_create_client(_url: str, _key: str) -> Any:
+        return fake_client
+
+    monkeypatch.setattr(db, "create_client", _fake_create_client)
+    db.user_client(USER_ID)
+    fake_client.postgrest.auth.assert_called_once()
+    (jwt_arg,), _ = fake_client.postgrest.auth.call_args
+    payload = jwt.decode(jwt_arg, JWT_SECRET, algorithms=["HS256"], audience="authenticated")
+    assert payload["sub"] == USER_ID

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -131,7 +131,8 @@ async def test_log_occurrence_creates_pattern_when_missing(
     def fake_insert_occ(*args: Any, **kw: Any) -> str:
         return OCCURRENCE_ID
 
-    def fake_update(*args: Any, **kw: Any) -> None:
+    def fake_update(user_id: str, *args: Any, **kw: Any) -> None:
+        assert user_id == USER_ID
         inserted["seen"] = True
 
     monkeypatch.setattr(db, "find_pattern_by_name", fake_find)

--- a/mcp/tools/patterns.py
+++ b/mcp/tools/patterns.py
@@ -73,7 +73,7 @@ async def log_occurrence(
         trigger,
         notes,
     )
-    await asyncio.to_thread(db.update_pattern_seen, pattern_id)
+    await asyncio.to_thread(db.update_pattern_seen, user_id, pattern_id)
     return occurrence_id
 
 

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -41,4 +41,14 @@ if [ -d "web/frontend" ]; then
   cd ../..
 fi
 
+echo "--- service-role boundary check (#44) ---"
+# Per #44, service_role / service_client must not appear in request-handling
+# code (mcp/, web/backend/). Tests legitimately reference them for historical
+# context so are excluded.
+if grep -rn --include='*.py' --exclude-dir=tests -E 'service_role|service_client' mcp/ web/backend/; then
+  echo "FAIL: service_role / service_client reference found in request-handling code."
+  echo "      Per #44, these are only allowed under scripts/ and supabase/."
+  exit 1
+fi
+
 echo "=== All gates passed ==="

--- a/supabase/migrations/002_service_role_audit.sql
+++ b/supabase/migrations/002_service_role_audit.sql
@@ -1,0 +1,57 @@
+-- Service-role boundary audit (#44).
+--
+-- Eliminates the remaining request-path uses of SUPABASE_SERVICE_ROLE_KEY by
+-- moving the privileged operations into RLS policies + security-definer
+-- functions. After this migration the MCP server and web backend can talk to
+-- Supabase using the anon key + the user's JWT only.
+
+-- ----------------------------------------------------------------------------
+-- connector_tokens: allow self-mints under RLS
+-- ----------------------------------------------------------------------------
+-- Lets POST /connect/token write its own row through user_client(jwt) instead
+-- of bypassing RLS with the service-role key.
+create policy "connector_tokens owner insert" on connector_tokens
+    for insert with check (auth.uid() = user_id);
+
+-- ----------------------------------------------------------------------------
+-- lookup_connector_token: anon-callable token resolution
+-- ----------------------------------------------------------------------------
+-- The MCP middleware needs to map a bearer token → user_id BEFORE it knows who
+-- the caller is, so an unauthenticated (anon) RPC is the only viable shape.
+-- Granted to anon AND authenticated; security definer + a constant-shape
+-- response (NULL on miss) avoids leaking timing/error oracles. Tokens are
+-- 32-byte URL-safe random, so enumeration is not a concern.
+create or replace function lookup_connector_token(p_token text)
+returns uuid
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select user_id from connector_tokens where token = p_token limit 1;
+$$;
+revoke all on function lookup_connector_token(text) from public;
+grant execute on function lookup_connector_token(text) to anon, authenticated;
+
+-- ----------------------------------------------------------------------------
+-- delete_my_account: self-service account deletion
+-- ----------------------------------------------------------------------------
+-- Replaces auth.admin.delete_user(user_id) in the web backend's DELETE
+-- /account route. The function deletes auth.users for auth.uid() (the caller
+-- can never specify another user's id) and the existing on-delete-cascade FKs
+-- propagate to every app table.
+create or replace function delete_my_account()
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+    if auth.uid() is null then
+        raise exception 'must be authenticated';
+    end if;
+    delete from auth.users where id = auth.uid();
+end;
+$$;
+revoke all on function delete_my_account() from public;
+grant execute on function delete_my_account() to authenticated;

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -50,4 +50,9 @@ async def get_current_user(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing subject"
         )
-    return {"user_id": user_id, "email": data.get("email"), "jwt": cred.credentials}
+    return {
+        "user_id": user_id,
+        "email": data.get("email"),
+        "jwt": cred.credentials,
+        "user_metadata": data.get("user_metadata") or {},
+    }

--- a/web/backend/db.py
+++ b/web/backend/db.py
@@ -1,14 +1,16 @@
-"""Supabase client factories.
+"""Supabase client factory + GoTrue self-service helpers.
 
-Routes use ``user_client`` so RLS scopes every query to the caller. Only the
-``connect.py`` token-mint route and ``DELETE /account`` use ``service_client``,
-both of which intentionally need to bypass RLS.
+Routes use ``user_client(jwt)`` so RLS scopes every query to the caller.
+Privileged operations (account deletion, connector-token mints) intentionally
+do NOT live in this module — they run through RLS policies and security-
+definer Postgres functions, see ``supabase/migrations/002_*.sql``.
 """
 
 from __future__ import annotations
 
-from functools import lru_cache
+from typing import Any, cast
 
+import httpx
 from supabase import Client, create_client
 
 from settings import settings
@@ -20,6 +22,22 @@ def user_client(user_jwt: str) -> Client:
     return client
 
 
-@lru_cache(maxsize=1)
-def service_client() -> Client:
-    return create_client(settings.supabase_url, settings.supabase_service_role_key)
+async def update_user_metadata(jwt: str, metadata: dict[str, Any]) -> dict[str, Any]:
+    """Self-service metadata update via GoTrue's PUT /auth/v1/user.
+
+    GoTrue's user-side endpoint expects ``{"data": {...}}`` (NOT
+    ``{"user_metadata": {...}}``). Returns the merged ``user_metadata`` from
+    the response so callers get the persisted state, not a local copy.
+    """
+    async with httpx.AsyncClient(timeout=10.0) as http:
+        resp = await http.put(
+            f"{settings.supabase_url.rstrip('/')}/auth/v1/user",
+            headers={
+                "apikey": settings.supabase_anon_key,
+                "Authorization": f"Bearer {jwt}",
+            },
+            json={"data": metadata},
+        )
+    resp.raise_for_status()
+    data = resp.json()
+    return cast(dict[str, Any], data.get("user_metadata") or {})

--- a/web/backend/routes/connect.py
+++ b/web/backend/routes/connect.py
@@ -26,7 +26,7 @@ def mint_token(
 ) -> dict[str, Any]:
     token = secrets.token_urlsafe(TOKEN_BYTES)
     res = (
-        db.service_client()
+        db.user_client(user["jwt"])
         .table("connector_tokens")
         .insert({"user_id": user["user_id"], "token": token})
         .execute()

--- a/web/backend/routes/settings.py
+++ b/web/backend/routes/settings.py
@@ -2,6 +2,9 @@
 
 Settings (timezone, transcript_enabled) live in ``auth.users.user_metadata``
 to avoid a 5th application table for what is, today, two scalar fields.
+GET reads ``user_metadata`` from the auth dependency (already fetched from
+GoTrue); PATCH writes via the self-service ``PUT /auth/v1/user``; DELETE
+calls the ``delete_my_account`` security-definer RPC.
 """
 
 from __future__ import annotations
@@ -23,19 +26,11 @@ class SettingsPatch(BaseModel):
     crisis_disclaimer_acknowledged_at: str | None = None
 
 
-def _user_metadata(user_id: str) -> dict[str, Any]:
-    res = db.service_client().auth.admin.get_user_by_id(user_id)
-    if res is None or res.user is None:
-        return {}
-    meta = getattr(res.user, "user_metadata", None) or {}
-    return cast(dict[str, Any], meta)
-
-
 @router.get("/settings")
 def get_settings(
     user: dict[str, Any] = Depends(get_current_user),
 ) -> dict[str, Any]:
-    meta = _user_metadata(user["user_id"])
+    meta = cast(dict[str, Any], user.get("user_metadata") or {})
     return {
         "timezone": meta.get("timezone"),
         "transcript_enabled": meta.get("transcript_enabled", True),
@@ -46,11 +41,11 @@ def get_settings(
 
 
 @router.patch("/settings")
-def update_settings(
+async def update_settings(
     patch: SettingsPatch,
     user: dict[str, Any] = Depends(get_current_user),
 ) -> dict[str, Any]:
-    current = _user_metadata(user["user_id"])
+    current = dict(cast(dict[str, Any], user.get("user_metadata") or {}))
     if patch.timezone is not None:
         current["timezone"] = patch.timezone
     if patch.transcript_enabled is not None:
@@ -59,13 +54,11 @@ def update_settings(
         current["crisis_disclaimer_acknowledged_at"] = (
             patch.crisis_disclaimer_acknowledged_at
         )
-    db.service_client().auth.admin.update_user_by_id(
-        user["user_id"], {"user_metadata": current}
-    )
+    merged = await db.update_user_metadata(user["jwt"], current)
     return {
-        "timezone": current.get("timezone"),
-        "transcript_enabled": current.get("transcript_enabled", True),
-        "crisis_disclaimer_acknowledged_at": current.get(
+        "timezone": merged.get("timezone"),
+        "transcript_enabled": merged.get("transcript_enabled", True),
+        "crisis_disclaimer_acknowledged_at": merged.get(
             "crisis_disclaimer_acknowledged_at"
         ),
     }
@@ -91,7 +84,7 @@ def export_data(
 def delete_account(
     user: dict[str, Any] = Depends(get_current_user),
 ) -> dict[str, str]:
-    # FK ON DELETE CASCADE on every user-owned table means the auth.users
-    # delete cleans up app data too.
-    db.service_client().auth.admin.delete_user(user["user_id"])
+    # The security-definer RPC deletes auth.users for auth.uid(); FK ON
+    # DELETE CASCADE on every user-owned table cleans up app data atomically.
+    db.user_client(user["jwt"]).rpc("delete_my_account").execute()
     return {"status": "deleted"}

--- a/web/backend/settings.py
+++ b/web/backend/settings.py
@@ -6,7 +6,6 @@ class Settings(BaseSettings):
 
     supabase_url: str = ""
     supabase_anon_key: str = ""
-    supabase_service_role_key: str = ""
     # HS256 path. RS256/JWKS support is the planned upgrade once we know the
     # production project's signing algorithm.
     supabase_jwt_secret: str = ""

--- a/web/backend/tests/test_auth.py
+++ b/web/backend/tests/test_auth.py
@@ -42,6 +42,38 @@ async def test_valid_token_returns_user() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_current_user_returns_user_metadata() -> None:
+    """user_metadata is surfaced so settings GET avoids a second admin round-trip."""
+    metadata = {"timezone": "Europe/London", "transcript_enabled": False}
+    mock_resp = _mock_supabase_response(
+        200, {"id": USER_ID, "email": "u@example.com", "user_metadata": metadata}
+    )
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    with patch("auth.httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        user = await get_current_user(_bearer())
+
+    assert user["user_metadata"] == metadata
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_user_metadata_defaults_to_empty_dict() -> None:
+    mock_resp = _mock_supabase_response(200, {"id": USER_ID, "email": "u@example.com"})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    with patch("auth.httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        user = await get_current_user(_bearer())
+
+    assert user["user_metadata"] == {}
+
+
+@pytest.mark.asyncio
 async def test_invalid_token_rejected() -> None:
     mock_resp = _mock_supabase_response(401, {"message": "Invalid JWT"})
     mock_client = AsyncMock()

--- a/web/backend/tests/test_routes.py
+++ b/web/backend/tests/test_routes.py
@@ -15,7 +15,12 @@ from auth import get_current_user
 from main import app
 
 USER_ID = "11111111-2222-3333-4444-555555555555"
-USER = {"user_id": USER_ID, "email": "u@example.com", "jwt": "fake-jwt"}
+USER = {
+    "user_id": USER_ID,
+    "email": "u@example.com",
+    "jwt": "fake-jwt",
+    "user_metadata": {},
+}
 
 
 @pytest.fixture
@@ -107,27 +112,13 @@ def test_export_data(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> Non
 def test_settings_patch_accepts_crisis_ack(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:
-    stored: dict[str, Any] = {"user_metadata": {}}
+    captured: dict[str, Any] = {}
 
-    def _service_client() -> MagicMock:
-        sb = MagicMock()
-        admin = MagicMock()
+    async def _fake_update(jwt: str, metadata: dict[str, Any]) -> dict[str, Any]:
+        captured["metadata"] = metadata
+        return metadata
 
-        def _get_user_by_id(_user_id: str) -> MagicMock:
-            res = MagicMock()
-            res.user = MagicMock()
-            res.user.user_metadata = stored["user_metadata"]
-            return res
-
-        def _update_user_by_id(_user_id: str, payload: dict[str, Any]) -> None:
-            stored["user_metadata"] = payload["user_metadata"]
-
-        admin.get_user_by_id.side_effect = _get_user_by_id
-        admin.update_user_by_id.side_effect = _update_user_by_id
-        sb.auth.admin = admin
-        return sb
-
-    monkeypatch.setattr(db, "service_client", _service_client)
+    monkeypatch.setattr(db, "update_user_metadata", _fake_update)
 
     res = client.patch(
         "/settings",
@@ -136,7 +127,7 @@ def test_settings_patch_accepts_crisis_ack(
     assert res.status_code == 200
     body = res.json()
     assert body["crisis_disclaimer_acknowledged_at"] == "2026-05-03T12:00:00Z"
-    assert stored["user_metadata"]["crisis_disclaimer_acknowledged_at"] == (
+    assert captured["metadata"]["crisis_disclaimer_acknowledged_at"] == (
         "2026-05-03T12:00:00Z"
     )
 
@@ -144,7 +135,7 @@ def test_settings_patch_accepts_crisis_ack(
 def test_mint_connector_token(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
     inserted: dict[str, Any] = {}
 
-    def _service_client() -> MagicMock:
+    def _build_user_client(_jwt: str) -> MagicMock:
         sb = MagicMock()
 
         def _table(name: str) -> MagicMock:
@@ -164,9 +155,94 @@ def test_mint_connector_token(monkeypatch: pytest.MonkeyPatch, client: TestClien
         sb.table.side_effect = _table
         return sb
 
-    monkeypatch.setattr(db, "service_client", _service_client)
+    monkeypatch.setattr(db, "user_client", _build_user_client)
     res = client.post("/connect/token")
     assert res.status_code == 200
     body = res.json()
     assert isinstance(body["token"], str) and len(body["token"]) > 20
     assert inserted["payload"]["user_id"] == USER_ID
+
+
+# ---------------------------------------------------------------------------
+# settings + account
+# ---------------------------------------------------------------------------
+def test_get_settings_reads_user_metadata() -> None:
+    user = {
+        **USER,
+        "user_metadata": {"timezone": "America/New_York", "transcript_enabled": False},
+    }
+    app.dependency_overrides[get_current_user] = lambda: user
+    try:
+        res = TestClient(app).get("/settings")
+    finally:
+        app.dependency_overrides.clear()
+    assert res.status_code == 200
+    assert res.json() == {
+        "timezone": "America/New_York",
+        "transcript_enabled": False,
+        "crisis_disclaimer_acknowledged_at": None,
+    }
+
+
+def test_get_settings_defaults_when_metadata_empty(client: TestClient) -> None:
+    res = client.get("/settings")
+    assert res.status_code == 200
+    assert res.json() == {
+        "timezone": None,
+        "transcript_enabled": True,
+        "crisis_disclaimer_acknowledged_at": None,
+    }
+
+
+def test_patch_settings_invokes_update_user_metadata(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _fake_update(jwt: str, metadata: dict[str, Any]) -> dict[str, Any]:
+        captured["jwt"] = jwt
+        captured["metadata"] = metadata
+        return metadata
+
+    monkeypatch.setattr(db, "update_user_metadata", _fake_update)
+    res = client.patch(
+        "/settings",
+        json={"timezone": "Europe/London", "transcript_enabled": False},
+    )
+    assert res.status_code == 200
+    assert captured["jwt"] == "fake-jwt"
+    assert captured["metadata"] == {
+        "timezone": "Europe/London",
+        "transcript_enabled": False,
+    }
+    assert res.json() == {
+        "timezone": "Europe/London",
+        "transcript_enabled": False,
+        "crisis_disclaimer_acknowledged_at": None,
+    }
+
+
+def test_delete_account_calls_rpc(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    rpc_calls: list[str] = []
+
+    def _build_user_client(_jwt: str) -> MagicMock:
+        sb = MagicMock()
+        rpc_chain = MagicMock()
+        rpc_response = MagicMock()
+        rpc_response.data = None
+        rpc_chain.execute.return_value = rpc_response
+
+        def _rpc(name: str) -> MagicMock:
+            rpc_calls.append(name)
+            return rpc_chain
+
+        sb.rpc.side_effect = _rpc
+        return sb
+
+    monkeypatch.setattr(db, "user_client", _build_user_client)
+    res = client.delete("/account")
+    assert res.status_code == 200
+    assert res.json() == {"status": "deleted"}
+    assert rpc_calls == ["delete_my_account"]


### PR DESCRIPTION
## Summary

Eliminates `SUPABASE_SERVICE_ROLE_KEY` from every request-handling code path in `mcp/` and `web/backend/`, replacing it with the **anon key + per-request user JWT** pattern so that Postgres Row Level Security is the only authority deciding which rows a query may touch.

Previously the MCP server used `service_role` exclusively (every tool call bypassed RLS), and the web backend used it in `/connect/token`, `/settings`, and `DELETE /account`. The defensive `eq("user_id", ...)` filter on every helper was the only thing standing between users and each other's data. After this change, RLS is the load-bearing guard — a missing filter or forged ID returns the user's own rows only.

Fixes #44.

## Changes

**Database / migration layer** (`supabase/migrations/002_service_role_audit.sql`):
- Adds an `INSERT WITH CHECK (auth.uid() = user_id)` policy on `connector_tokens`.
- Adds two `security definer` Postgres functions, both with `set search_path` and explicit grants:
  - `lookup_connector_token(text)` — returns the matching `user_id` for the MCP auth verifier (granted to `anon, authenticated`).
  - `delete_my_account()` — deletes `auth.users` row keyed on `auth.uid()` with cascade (granted to `authenticated` only).

**Application layer**:
- `mcp/db.py`: replaces `service_client()` with `user_client(user_id)` (mints a 5-minute HS256 JWT signed with `SUPABASE_JWT_SECRET`, claims `sub`/`role`/`aud=authenticated`) and `anon_client()` (no JWT, used only for the security-definer RPC). Refactors every helper. Rewrites `lookup_connector_token` as an anon RPC; deletes `insert_connector_token`.
- `mcp/tools/patterns.py`: passes `user_id` through to `update_pattern_seen` (its signature changed).
- `mcp/settings.py`, `web/backend/settings.py`: drop the `supabase_service_role_key` Pydantic field.
- `web/backend/routes/connect.py`: switches the connector-token insert to `user_client(jwt)`.
- `web/backend/routes/settings.py`: replaces `auth.admin.*` calls — GET reads `user_metadata` from the JWT user, PATCH calls a new `db.update_user_metadata` (httpx PUT to `/auth/v1/user`), `DELETE /account` calls `user_client(jwt).rpc("delete_my_account")`.
- `web/backend/auth.py`: surfaces `user_metadata` in `get_current_user` so settings GET no longer needs a second round-trip.
- `web/backend/db.py`: drops `service_client()`; adds the `update_user_metadata` httpx helper.
- `.env.example`: per-key, per-surface, per-misuse-consequence documentation block.
- `scripts/gates.sh`: new grep gate that fails CI if `service_role` / `service_client` reappears under `mcp/` or `web/backend/` (excluding tests). The gate caught a docstring leak during implementation, then went green after fix.

**Tests**:
- `mcp/tests/test_db.py` (new): asserts the internal JWT mint produces correct `sub`/`role`/`aud`/TTL claims and is signed with `supabase_jwt_secret` — guards against silent RLS breakage from claim typos.
- `mcp/tests/test_auth.py`: adds an unauthenticated-RPC propagation test.
- `mcp/tests/test_tools.py`: asserts `user_id` propagates into the new `update_pattern_seen` signature.
- `web/backend/tests/test_routes.py`: updates `test_mint_connector_token` to monkeypatch `db.user_client`; adds settings GET/PATCH and delete-account tests.
- `web/backend/tests/test_auth.py`: adds `user_metadata` coverage for `get_current_user`.

Total: 16 files changed, +444 / -95.

## Validation

| Check | Result |
|-------|--------|
| `mcp/` ruff | All checks passed |
| `mcp/` mypy | No issues, 10 source files |
| `mcp/` pytest | 62 passed |
| `web/backend/` ruff | All checks passed |
| `web/backend/` mypy | No issues, 11 source files |
| `web/backend/` pytest | 17 passed |
| `web/frontend/` lint + typecheck + vitest | 10 passed |
| Service-role boundary grep gate | Zero matches in `mcp/` and `web/backend/` |

Boundary proof:

```
$ grep -rn --include='*.py' --exclude-dir=tests -E 'service_role|service_client|SUPABASE_SERVICE_ROLE' mcp/ web/backend/
(no matches)
```

## Out of scope (follow-ups)

- Migration to RS256 / ES256 JWT signing (Supabase recommendation for OAuth/MCP scenarios).
- Renaming env vars to the new `sb_secret_*` / `sb_publishable_*` scheme.
- Quarterly rotation of `SUPABASE_SERVICE_ROLE_KEY` (ops task).
- Live `supabase db push` of `002_service_role_audit.sql` against a fresh project — local validation cannot exercise this; verify on next deploy.

## Test plan

- [ ] CI green on all gates (ruff, mypy, pytest, frontend lint/typecheck/tests, service-role grep gate).
- [ ] Apply migration `002_service_role_audit.sql` to a Supabase project; confirm `lookup_connector_token('nonexistent')` returns NULL and `delete_my_account()` raises "must be authenticated" when called as anon.
- [ ] Smoke test: MCP tool call against live Supabase succeeds (proves JWT `aud`/`role` claims are accepted by PostgREST).
- [ ] Smoke test: `POST /connect/token`, `GET /settings`, `PATCH /settings`, `DELETE /account` all succeed end-to-end on a real session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)