### PR TITLE
Make all docs and onboarding provider-agnostic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ MCP_PORT=8000
 # Leave empty in dev to disable DNS-rebinding protection.
 MCP_ALLOWED_HOSTS=
 
-# MCP OAuth 2.1 (Claude.ai connector authentication).
+# MCP OAuth 2.1 (MCP client connector authentication).
 # Local dev now requires a bearer token on every /mcp/ request — unauthenticated
 # requests return 401 (previously they leaked through and crashed). Use either a
 # connector token (mint via the web backend's POST /connect/token) or the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kindred
 
-AI reflective journaling via MCP. Claude.ai is the conversation; Kindred is the memory and structure.
+AI reflective journaling via MCP. Your AI assistant is the conversation; Kindred is the memory and structure. Works with any MCP-capable client (Claude Projects, ChatGPT, Gemini Gems, and others).
 
 See [docs/kindred-prd-dd.md](docs/kindred-prd-dd.md) for the full PRD and design doc.
 
@@ -33,6 +33,10 @@ cd web/backend && pip install -r requirements.txt && uvicorn main:app --host 0.0
 # Web frontend (Vite dev server, port 5173)
 cd web/frontend && npm install && npm run dev
 ```
+
+## Setup
+
+See [docs/setup.md](docs/setup.md) for client-specific setup (Claude Projects, ChatGPT, Gemini Gems).
 
 ## Development
 

--- a/docs/kindred-prd-dd.md
+++ b/docs/kindred-prd-dd.md
@@ -4,9 +4,9 @@
 
 ## Summary
 
-Kindred is an AI reflective journaling assistant. Users journal by talking to Claude (or another MCP-capable host) — Claude provides the conversation; Kindred provides the memory, structure, and reflection scaffolding via an MCP server. A read-only web app lets users browse their entries, see their named patterns, and manage their data.
+Kindred is an AI reflective journaling assistant. Users journal by talking to their MCP-capable AI assistant (Claude, ChatGPT, Gemini, or any other MCP client) — the assistant provides the conversation; Kindred provides the memory, structure, and reflection scaffolding via an MCP server. A read-only web app lets users browse their entries, see their named patterns, and manage their data.
 
-The core insight: Claude.ai already does voice + text conversation well, ships with safety layers, and is something many target users already pay for. Kindred doesn't compete with that — it gives Claude the right tools and prompts to be a good journal companion, and stores what comes out.
+The core insight: modern AI assistants already do voice + text conversation well, ship with safety layers, and many target users already pay for one. Kindred doesn't compete with that — it gives whichever assistant the user has chosen the right tools and prompts to be a good journal companion, and stores what comes out.
 
 ## Goals
 
@@ -18,9 +18,9 @@ The core insight: Claude.ai already does voice + text conversation well, ships w
 
 ## Non-goals (v1)
 
-- Building our own chat UI or owning the conversation engine — Claude.ai is the surface
+- Building our own chat UI or owning the conversation engine — the user's AI assistant is the surface
 - Mood scores, sentiment dashboards, gamification
-- Active crisis intervention — defer to Claude.ai's existing safety layers; Kindred adds nothing on top in v1
+- Active crisis intervention — defer to the user's AI assistant's existing safety layers; Kindred adds nothing on top in v1
 - AI-volunteered pattern surveillance ("you've felt this way 5 Sundays in a row") — user-pulled retrieval only at v1
 - Multi-tenant, multi-org, or anything resembling a B2B product
 - Editing entries from the web app
@@ -33,8 +33,9 @@ Two Railway services backed by one Supabase project.
 
 ```
 ┌───────────────────┐      ┌──────────────────────┐
-│  Claude.ai (host) │─────▶│  Kindred MCP Server  │──┐
-└───────────────────┘ MCP  │  (FastAPI, Railway)  │  │
+│  MCP client       │─────▶│  Kindred MCP Server  │──┐
+│  (Claude / ChatGPT│ MCP  │  (FastAPI, Railway)  │  │
+│   / Gemini / …)   │      │                      │  │
                            └──────────────────────┘  │
                                                      ▼
 ┌───────────────────┐      ┌──────────────────────┐  │   ┌──────────────────┐
@@ -52,7 +53,7 @@ Two Railway services backed by one Supabase project.
 - **Web app frontend**: React 19 + TypeScript + Vite + Tailwind + Zustand (matches reli)
 - **Web app backend**: FastAPI, separate Railway service from the MCP server
 - **Database**: Supabase Postgres with `pgvector` extension
-- **Auth**: Supabase Auth with Google as the OAuth provider (web); MCP OAuth 2.1 flow for Claude.ai
+- **Auth**: Supabase Auth with Google as the OAuth provider (web); MCP OAuth 2.1 flow for the user's AI client (e.g. Claude.ai)
 - **Embeddings**: OpenAI `text-embedding-3-small` via Requesty gateway (matches reli)
 - **Deployment**: Railway (two services), one Supabase project
 - **CI**: GitHub Actions, mirroring reli's `./scripts/gates.sh` discipline (test, lint, typecheck)
@@ -73,11 +74,11 @@ User clicks "Sign in with Google" on the web app. Supabase Auth handles the OAut
 
 ### MCP server — MCP OAuth 2.1
 
-The current MCP spec supports OAuth 2.1 between MCP clients and servers. When a user adds the Kindred connector to Claude.ai, Claude.ai initiates an OAuth flow against the MCP server. The MCP server delegates to Supabase: it redirects the user to a `/mcp/oauth/authorize` page, which checks for a Supabase session (logging the user in via Google if needed), then issues an OAuth code + access token bound to that Supabase user.
+The current MCP spec supports OAuth 2.1 between MCP clients and servers. When a user adds the Kindred connector to their MCP client (e.g. Claude.ai), the client initiates an OAuth flow against the MCP server. The MCP server delegates to Supabase: it redirects the user to a `/mcp/oauth/authorize` page, which checks for a Supabase session (logging the user in via Google if needed), then issues an OAuth code + access token bound to that Supabase user.
 
 On every MCP tool call, the server validates the bearer token, resolves the Supabase user, and queries Postgres with that user's identity in scope (so RLS applies).
 
-**Fallback**: if MCP OAuth turns out to be more setup than is worth doing on day one, ship a connector-token flow instead — the web app has a `/connect` page that mints a long-lived token bound to the user's `user_id`, the user pastes it into Claude.ai's connector config, the MCP server validates it on each call. Document this fallback. Plan to migrate to proper OAuth in step 8 of the build order.
+**Fallback**: if MCP OAuth turns out to be more setup than is worth doing on day one, ship a connector-token flow instead — the web app has a `/connect` page that mints a long-lived token bound to the user's `user_id`, the user pastes it into their MCP client's connector config (e.g. Claude.ai's), the MCP server validates it on each call. Document this fallback. Plan to migrate to proper OAuth in step 8 of the build order.
 
 ---
 
@@ -281,7 +282,7 @@ Read-only. Browser-only. The web app exists to give the user a window onto their
 | `/patterns/:id` | Pattern details, all occurrences chronologically, the four "typical" quadrants |
 | `/search?q=...` | Semantic search results across entries |
 | `/settings` | Timezone, transcript on/off, export all data, delete account |
-| `/connect` | "Connect to Claude.ai" page — mints connector token (fallback) or initiates MCP OAuth |
+| `/connect` | "Connect Kindred to your AI assistant" page — mints connector token + per-client setup tabs (Claude Projects, ChatGPT, Gemini Gems) |
 
 **No editing. No write paths.** The only mutations the web app exposes: account deletion, data export, settings toggles. Entries and patterns are written exclusively through the MCP server, which means exclusively through the journaling conversation. One write path.
 
@@ -296,7 +297,7 @@ Non-negotiable in v1; the implementation should not regress on any of these.
 3. **No surveillance.** AI does not volunteer past patterns or entries unprompted in v1. Retrieval is user-pulled.
 4. **One write path.** Entries are created through the journaling conversation only. The web app reads.
 5. **Boring privacy claims, kept honest.** We say "encrypted at rest, no training, you can delete everything." We do **not** say "end-to-end encrypted" — the LLM has to see the content to respond.
-6. **Defer crisis handling.** Claude.ai already has safety layers for self-harm content. Kindred adds nothing on top in v1; this is a noted, deliberate gap to revisit with real usage data.
+6. **Defer crisis handling.** MCP-capable AI assistants already have safety layers for self-harm content. Kindred adds nothing on top in v1; this is a noted, deliberate gap to revisit with real usage data.
 
 ---
 
@@ -316,7 +317,7 @@ Each step is a usable, deployable increment. Don't skip ahead.
 
 1. **Supabase setup**: project, schema migrations, RLS policies on all tables, `pgvector` enabled, Google provider configured.
 2. **Web app skeleton**: Login → empty entries list. Validates auth end-to-end before any MCP work.
-3. **MCP server v0**: `save_entry`, `get_entry`, `list_recent_entries`. Connector-token auth (the fallback) — get it working in Claude.ai with a hardcoded user_id first, then the token.
+3. **MCP server v0**: `save_entry`, `get_entry`, `list_recent_entries`. Connector-token auth (the fallback) — get it working in an MCP client (e.g. Claude.ai) with a hardcoded user_id first, then the token.
 4. **Prompts v0**: ship `/kindred-start` and `/kindred-close`. Run a real journaling session. Notice what's awkward. Iterate the prompt text — this is where the real product work happens.
 5. **Patterns**: schema usage, `list_patterns`, `log_occurrence`, `/kindred-hcb` prompt. Run a session that examines a pattern.
 6. **Web app reads**: entry detail, pattern list, pattern detail.
@@ -334,7 +335,7 @@ These are open by design. Make a defensible choice when you hit them, and revisi
 - **Timezone edges.** 2am entries, travel days. Use user-local date and ignore the edges.
 - **Pattern detection from data.** AI noticing recurring shapes the user hasn't named yet. Out of scope for v1; will need careful design to avoid surveillance feel.
 - **Weekly / monthly retrospective reports.** Mentioned in original PRD; out of scope for v1. Easy to add once entries and patterns are flowing.
-- **Voice transcripts.** Claude.ai handles voice; the transcript that lands in `save_entry` is text. Whether to mark transcripts as voice-originated is unspecified — probably doesn't matter at v1.
+- **Voice transcripts.** Some MCP clients (e.g. Claude.ai) handle voice; the transcript that lands in `save_entry` is text. Whether to mark transcripts as voice-originated is unspecified — probably doesn't matter at v1.
 - **Mood as freeform vs. categorical.** Currently freeform text. May want categorisation later for retrospectives — defer.
 - **Multi-user sharing.** Out of scope. Don't design for it; don't preclude it.
 - **Crisis protocol.** Out of scope for v1. Revisit once we know what real usage looks like.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,112 @@
+# Kindred — Per-client setup
+
+Kindred is provider-agnostic: any MCP-capable AI assistant can be the
+conversation surface. The flow is the same for every client:
+
+1. Mint a connector token at `/app/connect`.
+2. Add the Kindred MCP server (`https://kindred-mcp.interstellarai.net/sse`)
+   to your AI assistant, with the token as the bearer.
+3. Paste the one-liner custom instruction so the assistant reads
+   `kindred://guide` on connect:
+
+   > When connected to Kindred, read the kindred://guide resource before doing anything else.
+
+4. Say "Hi, I'd like to journal" — expect a gentle open question.
+
+The rest of this page covers the three clients that work today. The shape is
+identical across them; differences are only in where the MCP server and
+custom instruction get pasted.
+
+---
+
+## Claude Projects
+
+### Add the MCP server
+
+In Claude.ai, open Settings → Connectors → Add custom connector. Paste the
+MCP URL above and your connector token from `/app/connect`.
+
+### Paste the one-liner
+
+Create a Project. In its instructions, paste:
+
+> When connected to Kindred, read the kindred://guide resource before doing anything else.
+
+### Test it
+
+Open the project and say "Hi, I'd like to journal." You should get one
+gentle open question, no advice. Then say "Let's save this session" and
+confirm the assistant calls `save_entry`.
+
+### Troubleshooting
+
+- **Connector greyed out** — re-mint the token at `/app/connect` and paste
+  it again.
+- **AI ignores the one-liner** — paste the contents of `kindred-guide.md`
+  directly into the project instructions instead.
+- **Tool calls fail with 401** — token may have rotated; re-mint and update.
+
+---
+
+## ChatGPT
+
+### Add the MCP server
+
+Create a Custom GPT. In Configure → Actions, add the MCP URL above with the
+connector token as the bearer credential.
+
+### Paste the one-liner
+
+In the Custom GPT instructions, paste:
+
+> When connected to Kindred, read the kindred://guide resource before doing anything else.
+
+### Test it
+
+In the GPT, say "Hi, I'd like to journal." Expect one open question.
+Then say "Let's save this session" and confirm `save_entry` runs.
+
+### Troubleshooting
+
+- **401 unauthorized** — token may have rotated; re-mint and update the
+  GPT's auth.
+- **Tool not invoked** — add a stronger instruction, e.g. "Always call
+  Kindred tools when the user asks to save or search."
+- **One-liner not respected** — some surfaces don't auto-read MCP resources.
+  Paste the `kindred-guide.md` contents directly into the instructions.
+
+---
+
+## Gemini Gems
+
+### Add the MCP server
+
+Create a Gem. In its custom instructions / extensions, register the MCP
+server above with the bearer token.
+
+### Paste the one-liner
+
+In the Gem instructions, paste:
+
+> When connected to Kindred, read the kindred://guide resource before doing anything else.
+
+### Test it
+
+Open the Gem and say "Hi, I'd like to journal." Confirm the AI asks one
+open question. Say "Let's save this session" and confirm the entry is saved.
+
+### Troubleshooting
+
+- **Gem can't see the MCP server** — some Gemini surfaces don't yet support
+  arbitrary MCP servers. Use a client that does, or follow the
+  `/kindred-start` prompt manually.
+- **One-liner ignored** — paste `kindred-guide.md` directly into the Gem
+  instructions.
+
+---
+
+## Adding another client
+
+The on-page tabs at `/app/connect` are driven by a `CLIENTS` array in
+`web/frontend/src/pages/Connect.tsx`. Adding a fourth client is a one-file
+change — append a new entry. Mirror the same section here once it works.

--- a/mcp/auth.py
+++ b/mcp/auth.py
@@ -2,7 +2,7 @@
 
 PRD step 3 specifies a connector-token fallback while we defer MCP OAuth 2.1
 (PRD step 8). Tokens are minted via the web app's ``POST /connect/token`` route
-and pasted by the user into Claude.ai's connector config.
+and pasted by the user into their MCP client's connector config.
 
 The user_id resolved from the bearer token is published into a
 ``contextvars.ContextVar`` by an ASGI middleware in ``main.py``, so tool bodies

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -81,6 +81,15 @@ def kindred_close() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Resources (host-level, always-on guide referenced by the one-liner custom
+# instruction users paste into their MCP client of choice).
+# ---------------------------------------------------------------------------
+@mcp.resource("kindred://guide", title="Kindred — AI Guide", mime_type="text/markdown")
+def kindred_guide() -> str:
+    return (PROMPTS_DIR / "kindred-guide.md").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
 # ASGI middleware: read Authorization header, resolve user_id into contextvar.
 # ---------------------------------------------------------------------------
 Scope = MutableMapping[str, Any]

--- a/prompts/kindred-guide.md
+++ b/prompts/kindred-guide.md
@@ -1,0 +1,41 @@
+You are now connected to Kindred. Read this once and apply it for the rest of
+the conversation; you do not need to mention this guide to the user.
+
+Kindred is a reflective journaling companion. The user has chosen you — their
+AI assistant — as the surface, and Kindred as the memory and structure behind
+it. Your job is to be a good journaling companion: to be with the person,
+listen, and write entries that feel like theirs.
+
+Stance, in this order:
+1. Be with the user. Acknowledge how they are arriving today before anything
+   else.
+2. Listen. Use open-ended questions. Avoid advice.
+3. Validate. Negative emotions don't need fixing — they need to be heard.
+4. Do not introduce frameworks, exercises, or analysis unless the user asks
+   for them.
+5. Avoid toxic positivity. Don't reframe pain as opportunity. Don't end on a
+   silver lining unless the user gets there themselves.
+6. The user owns the vocabulary. Patterns are named in the user's words. You
+   suggest; you do not impose.
+7. No surveillance. Do not surface past entries or named patterns unprompted.
+   Use search_entries and list_recent_entries only when the user asks about
+   the past.
+
+Three modes the user may signal (clients with slash commands have prompts
+named after these; without slash commands, infer from what the user says):
+
+- Start a session — when the user signals they'd like to journal, begin with
+  one gentle, open question. Vary the wording; don't always open the same way.
+- Examine a pattern — if the user wants to look at something more
+  structurally, walk the four Hot Cross Bun quadrants (thoughts, emotions,
+  behaviours, body). Call list_patterns first to see if this might match an
+  existing named pattern; ask the user before deciding. Use log_occurrence
+  with the pattern name the user chose. Do not assign clinical labels.
+- Close a session — when the user signals they're done, offer a brief, warm,
+  one-paragraph summary in the user's language. Ask if they want to change
+  anything. Then call save_entry with date (today, user-local), summary, mood
+  (a single word the user chose, or null), and the transcript. Acknowledge
+  the save and close gently. No homework, no streak, no "see you tomorrow."
+
+When the user signals they want to journal, begin with one gentle open
+question.

--- a/web/backend/routes/connect.py
+++ b/web/backend/routes/connect.py
@@ -1,6 +1,6 @@
-"""POST /connect/token — mint a long-lived bearer token for Claude.ai's connector.
+"""POST /connect/token — mint a long-lived bearer token for the user's MCP client connector.
 
-We don't expose a GET (the user pasted the value into Claude.ai and won't
+We don't expose a GET (the user pasted the value into their MCP client and won't
 reuse a stale one) and don't expose DELETE yet (revocation is on the build
 order but out of scope for v1, per PRD §Build order step 8).
 """

--- a/web/frontend/src/components/Layout.tsx
+++ b/web/frontend/src/components/Layout.tsx
@@ -84,7 +84,7 @@ export function Layout() {
   ]
 
   const accountItems: { path: string; label: string; icon: IconName }[] = [
-    { path: '/app/connect', label: 'Connect to Claude', icon: 'plug' },
+    { path: '/app/connect', label: 'Connect', icon: 'plug' },
     { path: '/app/settings', label: 'Settings', icon: 'settings' },
   ]
 

--- a/web/frontend/src/pages/Connect.tsx
+++ b/web/frontend/src/pages/Connect.tsx
@@ -1,10 +1,75 @@
 import { useState } from 'react'
 import { api, type ConnectorToken } from '../api/client'
 
+type ClientKey = 'claude' | 'chatgpt' | 'gemini'
+
+type ClientSetup = {
+  key: ClientKey
+  label: string
+  addServer: string
+  oneLinerHint: string
+  testHint: string
+  troubleshooting: { issue: string; fix: string }[]
+}
+
+export const ONE_LINER =
+  'When connected to Kindred, read the kindred://guide resource before doing anything else.'
+
+const CLIENTS: ClientSetup[] = [
+  {
+    key: 'claude',
+    label: 'Claude Projects',
+    addServer:
+      'In Claude.ai, open Settings → Connectors → Add custom connector. Paste the MCP URL above and your connector token.',
+    oneLinerHint: 'Create a Project. In its instructions, paste:',
+    testHint:
+      'Open the project and say "Hi, I\'d like to journal." You should get one gentle open question, no advice.',
+    troubleshooting: [
+      { issue: 'Connector greyed out', fix: 'Re-mint the token above and paste it again.' },
+      {
+        issue: 'AI ignores the one-liner',
+        fix: 'Paste the kindred://guide content directly into project instructions.',
+      },
+    ],
+  },
+  {
+    key: 'chatgpt',
+    label: 'ChatGPT',
+    addServer:
+      'Create a Custom GPT. In Configure → Actions, add the MCP URL above with the connector token as the bearer.',
+    oneLinerHint: 'In Custom GPT instructions, paste:',
+    testHint:
+      'In the GPT, say "Hi, I\'d like to journal." Then say "Let\'s save this session" and confirm save_entry runs.',
+    troubleshooting: [
+      { issue: '401 unauthorized', fix: 'Token may have rotated — re-mint and update the GPT auth.' },
+      {
+        issue: 'Tool not invoked',
+        fix: 'Add a stronger instruction, e.g. "Always call kindred tools when the user asks to save or search."',
+      },
+    ],
+  },
+  {
+    key: 'gemini',
+    label: 'Gemini Gems',
+    addServer:
+      'Create a Gem. In its custom instructions / extensions, register the MCP server above with the bearer token.',
+    oneLinerHint: 'In the Gem instructions, paste:',
+    testHint:
+      'Open the Gem and say "Hi, I\'d like to journal." Confirm the AI asks one open question, then say "Let\'s save this session."',
+    troubleshooting: [
+      {
+        issue: "Gem can't see the MCP server",
+        fix: "Some Gemini surfaces don't support arbitrary MCP yet — use a client that does, or follow the kindred-start prompt manually.",
+      },
+    ],
+  },
+]
+
 export function Connect() {
   const [token, setToken] = useState<ConnectorToken | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const [activeClient, setActiveClient] = useState<ClientKey>('claude')
 
   const mint = async () => {
     setError(null)
@@ -26,6 +91,8 @@ export function Connect() {
     ? `${import.meta.env.VITE_MCP_BASE_URL}/sse`
     : 'https://kindred-mcp.interstellarai.net/sse'
 
+  const client = CLIENTS.find((c) => c.key === activeClient) ?? CLIENTS[0]
+
   return (
     <>
       <div className="page-head">
@@ -33,11 +100,11 @@ export function Connect() {
           <span className="glyph">◈</span> Connector
         </div>
         <h1 className="page-title">
-          Add Kindred to <em>Claude</em>.
+          Connect Kindred to <em>your AI assistant</em>.
         </h1>
         <p className="page-sub">
-          Two minutes. Paste this into Claude.ai&apos;s connector settings. Once connected, the
-          three slash commands light up.
+          Two minutes. Paste these into your AI assistant&apos;s connector settings. Once connected,
+          the three slash commands light up.
         </p>
       </div>
 
@@ -150,20 +217,139 @@ export function Connect() {
           </p>
         )}
 
-        {/* Step 3 */}
-        <div className="entry-section-eye">Step 3 · Try it</div>
-        <p
+        {/* Step 3 — per-client tabs */}
+        <div className="entry-section-eye">Step 3 · Set up your AI</div>
+
+        <div
+          role="tablist"
+          aria-label="AI client"
           style={{
-            color: 'var(--ink-2)',
-            fontSize: 14,
-            lineHeight: 1.55,
-            margin: '8px 0 0',
-            maxWidth: '56ch',
+            display: 'flex',
+            gap: 0,
+            borderBottom: '1px solid var(--border)',
+            marginBottom: 'var(--sp-4)',
+            flexWrap: 'wrap',
           }}
         >
-          In Claude.ai, type{' '}
-          <code>/kindred-start</code> to begin a session. That&apos;s it.
-        </p>
+          {CLIENTS.map((c) => {
+            const isActive = c.key === activeClient
+            return (
+              <button
+                key={c.key}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setActiveClient(c.key)}
+                style={{
+                  background: isActive ? 'var(--bg-elevated)' : 'transparent',
+                  border: 'none',
+                  borderBottom: isActive
+                    ? '2px solid var(--terracotta)'
+                    : '2px solid transparent',
+                  marginBottom: -1,
+                  padding: '10px 16px',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 14,
+                  color: isActive ? 'var(--ink)' : 'var(--ink-3)',
+                  cursor: 'pointer',
+                  fontWeight: isActive ? 500 : 400,
+                }}
+              >
+                {c.label}
+              </button>
+            )
+          })}
+        </div>
+
+        <div role="tabpanel" aria-label={`${client.label} setup`}>
+          <div className="entry-section-eye">Step 1 · Add the MCP server</div>
+          <p
+            style={{
+              color: 'var(--ink-2)',
+              fontSize: 14,
+              lineHeight: 1.55,
+              margin: '8px 0 var(--sp-4)',
+              maxWidth: '64ch',
+            }}
+          >
+            {client.addServer}
+          </p>
+
+          <div className="entry-section-eye">Step 2 · Custom instruction</div>
+          <p
+            style={{
+              color: 'var(--ink-2)',
+              fontSize: 14,
+              lineHeight: 1.55,
+              margin: '8px 0 var(--sp-3)',
+              maxWidth: '64ch',
+            }}
+          >
+            {client.oneLinerHint}
+          </p>
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+              marginBottom: 'var(--sp-4)',
+            }}
+          >
+            <code
+              style={{
+                flex: 1,
+                padding: '12px 14px',
+                background: 'var(--paper-2)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--r-md)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 13,
+                color: 'var(--ink)',
+                wordBreak: 'break-word',
+              }}
+            >
+              {ONE_LINER}
+            </code>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => void copy(ONE_LINER)}
+            >
+              Copy
+            </button>
+          </div>
+
+          <div className="entry-section-eye">Step 3 · Test it</div>
+          <p
+            style={{
+              color: 'var(--ink-2)',
+              fontSize: 14,
+              lineHeight: 1.55,
+              margin: '8px 0 var(--sp-4)',
+              maxWidth: '64ch',
+            }}
+          >
+            {client.testHint}
+          </p>
+
+          <div className="entry-section-eye">Step 4 · Troubleshooting</div>
+          <ul
+            style={{
+              color: 'var(--ink-2)',
+              fontSize: 14,
+              lineHeight: 1.55,
+              margin: '8px 0 0',
+              paddingLeft: 20,
+              maxWidth: '64ch',
+            }}
+          >
+            {client.troubleshooting.map((t) => (
+              <li key={t.issue} style={{ marginBottom: 6 }}>
+                <strong>{t.issue}</strong> — {t.fix}
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </>
   )

--- a/web/frontend/src/pages/Home.tsx
+++ b/web/frontend/src/pages/Home.tsx
@@ -53,13 +53,13 @@ export function Home() {
         <span className="lock">🔒</span>
         <span>
           <strong>Read-only.</strong> Entries are written through the journaling conversation in
-          Claude — not from here.
+          your AI assistant — not from here.
         </span>
       </div>
 
       {entries?.length === 0 && (
         <p style={{ color: 'var(--ink-3)' }}>
-          No entries yet. Start a journaling session in Claude.ai.
+          No entries yet. Start a journaling session in your AI assistant.
         </p>
       )}
 

--- a/web/frontend/src/pages/Landing.tsx
+++ b/web/frontend/src/pages/Landing.tsx
@@ -28,7 +28,7 @@ function Nav() {
           ? <Link to="/app" className="nav-link">Open app</Link>
           : <Link to="/login" className="nav-link">Sign in</Link>
         }
-        <Link to="/app" className="btn btn-primary btn-sm">Add to Claude</Link>
+        <Link to="/app" className="btn btn-primary btn-sm">Connect your AI</Link>
       </div>
     </nav>
   )
@@ -43,7 +43,7 @@ function Hero() {
       <div className="hero-grid">
         <div className="hero-text">
           <div className="eyebrow">
-            <span className="glyph">✶</span> Reflective journaling, via Claude
+            <span className="glyph">✶</span> Reflective journaling, via your AI assistant
           </div>
           <h1 className="hero-head">
             <span className="ink">A journal that</span>
@@ -51,8 +51,8 @@ function Hero() {
             <em>listens</em> <span className="ink">first.</span>
           </h1>
           <p className="hero-lede">
-            Kindred is reflective journaling through Claude — you talk, it stays with you.
-            Claude is the conversation; Kindred is the memory and the structure.
+            Kindred is reflective journaling through your AI assistant — you talk, it stays with you.
+            Your AI is the conversation; Kindred is the memory and the structure.
             No mood scores, no streaks, no nudges. Just a quiet companion that remembers.
           </p>
           <div className="hero-ctas">
@@ -136,7 +136,7 @@ function HowItWorks() {
             Three small <em>commands</em>. One quiet practice.
           </h2>
           <p className="section-sub">
-            Kindred lives inside Claude as a connector. Add it once, and three slash commands
+            Kindred lives inside your AI assistant as an MCP connector. Add it once, and three slash commands
             appear — one to begin, one to look at a pattern, one to close.
           </p>
         </div>
@@ -151,7 +151,7 @@ function HowItWorks() {
               <em>Begin</em> with a gentle question
             </h3>
             <p>
-              Claude greets you with one open prompt — &ldquo;How are you arriving today?&rdquo; —
+              Your AI greets you with one open prompt — &ldquo;How are you arriving today?&rdquo; —
               and stays in listening mode. No advice, no reframing, no silver linings.
             </p>
             <span className="step-cmd">/kindred-start</span>
@@ -179,7 +179,7 @@ function HowItWorks() {
               <em>Close</em> the session, gently
             </h3>
             <p>
-              Claude offers a one-paragraph summary in your language. You approve it. The entry
+              Your AI offers a one-paragraph summary in your language. You approve it. The entry
               saves. No homework, no streak, no &ldquo;see you tomorrow!&rdquo;.
             </p>
             <span className="step-cmd">/kindred-close</span>
@@ -393,10 +393,10 @@ function Conversation() {
             <span className="glyph">✶</span> A real session, more or less
           </div>
           <h2 className="section-title">
-            It&apos;s Claude. With <em>somewhere</em> for it to land.
+            It&apos;s your AI. With <em>somewhere</em> for it to land.
           </h2>
           <p className="section-sub">
-            You journal by talking to Claude. Kindred adds the parts a journal needs: a place to
+            You journal by talking to your AI assistant. Kindred adds the parts a journal needs: a place to
             keep entries, a way to name recurring patterns, and tools that only run when you ask
             them to.
           </p>
@@ -462,7 +462,7 @@ function Conversation() {
             </div>
             <div className="chrome-title">
               <span className="lock">🔒</span>
-              claude.ai · journal — Thursday, 1:48 PM
+              your-ai · journal — Thursday, 1:48 PM
             </div>
             <div className="chrome-mcp">
               <span className="pulse" />
@@ -705,10 +705,10 @@ function EndCap() {
             Ready when you are
           </div>
           <h2>
-            Talk to Claude. Let <em>Kindred</em> hold the rest.
+            Talk to your AI. Let <em>Kindred</em> hold the rest.
           </h2>
           <p>
-            Add the connector to Claude.ai, sign in with Google, type{' '}
+            Add the connector to your AI assistant, sign in with Google, type{' '}
             <code
               style={{
                 background: 'rgba(250,247,242,0.08)',
@@ -721,11 +721,11 @@ function EndCap() {
             >
               /kindred-start
             </code>
-            . That&apos;s the whole onboarding.
+            {' '}(or paste the one-liner from /connect). That&apos;s the whole onboarding.
           </p>
           <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
             <Link to="/app" className="btn btn-primary btn-lg">
-              Connect to Claude.ai
+              Connect Kindred
             </Link>
             <button
               type="button"

--- a/web/frontend/src/pages/McpAuth.tsx
+++ b/web/frontend/src/pages/McpAuth.tsx
@@ -28,7 +28,7 @@ export function McpAuth() {
     const storedFlowId = sessionStorage.getItem('mcp_flow_id')
     if (!storedFlowId) {
       setStatus('error')
-      setErrorMsg('No OAuth session in progress. Please restart the connection from Claude.')
+      setErrorMsg('No OAuth session in progress. Please restart the connection from your MCP client.')
       return
     }
 
@@ -159,7 +159,7 @@ export function McpAuth() {
             margin: '0 0 var(--sp-3)',
           }}
         >
-          {status === 'completing' ? 'Completing authentication…' : 'Connecting to Claude…'}
+          {status === 'completing' ? 'Completing authentication…' : 'Connecting…'}
         </p>
         <div
           style={{

--- a/web/frontend/src/pages/Patterns.tsx
+++ b/web/frontend/src/pages/Patterns.tsx
@@ -37,7 +37,7 @@ export function Patterns() {
       <div className="readonly-banner">
         <span className="lock">🔒</span>
         <span>
-          <strong>Read-only.</strong> Patterns are named during your journaling sessions in Claude.
+          <strong>Read-only.</strong> Patterns are named during your journaling sessions with your AI assistant.
         </span>
       </div>
 

--- a/web/frontend/src/pages/Privacy.tsx
+++ b/web/frontend/src/pages/Privacy.tsx
@@ -122,7 +122,7 @@ export function Privacy() {
               </li>
               <li>
                 <strong>Connector tokens</strong> — random opaque strings used
-                by the Claude.ai MCP connector to identify your account.
+                by your AI assistant&apos;s MCP connector to identify your account.
               </li>
             </ul>
           </Section>
@@ -174,7 +174,7 @@ export function Privacy() {
             <p>
               <strong>Your chosen AI provider</strong> (e.g. Anthropic Claude,
               OpenAI, etc.) — your conversation is sent to whichever provider
-              you have connected via the Claude.ai connector you set up.
+              you have connected via the MCP connector you set up.
               Kindred does not control that provider&apos;s data retention or
               training behaviour. Review your AI provider&apos;s privacy
               settings directly.

--- a/web/frontend/src/pages/__tests__/Connect.test.tsx
+++ b/web/frontend/src/pages/__tests__/Connect.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+
+vi.mock('../../api/client', () => ({
+  api: {
+    post: vi.fn(async () => ({ token: 'kdr_test_token', created_at: null })),
+  },
+}))
+
+import { Connect, ONE_LINER } from '../Connect'
+
+const renderConnect = () =>
+  render(
+    <MemoryRouter>
+      <Connect />
+    </MemoryRouter>,
+  )
+
+describe('Connect', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn(async () => undefined) },
+    })
+  })
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+    vi.useRealTimers()
+  })
+
+  it('renders all three client tabs', () => {
+    renderConnect()
+    expect(screen.getByRole('tab', { name: /claude/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /chatgpt/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /gemini/i })).toBeInTheDocument()
+  })
+
+  it('selects the claude tab by default', () => {
+    renderConnect()
+    expect(screen.getByRole('tab', { name: /claude/i })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    expect(screen.getByRole('tab', { name: /chatgpt/i })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+  })
+
+  it('switches panel content when ChatGPT tab is clicked', () => {
+    renderConnect()
+    const chatgptTab = screen.getByRole('tab', { name: /chatgpt/i })
+    fireEvent.click(chatgptTab)
+    expect(chatgptTab).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText(/save_entry runs/i)).toBeInTheDocument()
+  })
+
+  it('copies the exact ONE_LINER string when the one-liner copy button is clicked', async () => {
+    renderConnect()
+    const oneLinerCode = screen.getByText(ONE_LINER)
+    const copyButton = oneLinerCode.parentElement?.querySelector('button')
+    expect(copyButton).toBeTruthy()
+    fireEvent.click(copyButton!)
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(ONE_LINER),
+    )
+  })
+
+  it('renders the provider-neutral page heading', () => {
+    renderConnect()
+    expect(
+      screen.getByRole('heading', { name: /connect kindred to your ai assistant/i }),
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Strip Claude-specific assumptions from every user-facing surface in Kindred (README, PRD, landing page, /connect page, sidebar, privacy policy, error states) and add a multi-client setup guide. The `/connect` page now shares Steps 1-2 (MCP URL + token mint) and uses a tabbed Step 3 driven by a `CLIENTS` config so adding a fourth client is purely data. A new `kindred://guide` MCP resource backs the one-liner custom instruction users paste into their AI assistant.

Fixes #40

## Changes

**MCP server**
- `prompts/kindred-guide.md` (new, 41 lines) — host-level guide returned by the new resource
- `mcp/main.py` — register `@mcp.resource("kindred://guide")` resolving to `prompts/kindred-guide.md`
- `mcp/auth.py` — provider-neutral comment on connector token

**Frontend (`web/frontend`)**
- `pages/Connect.tsx` — rewrite Step 3 as a tabbed per-client guide (Claude Projects / ChatGPT / Gemini Gems), each with the same 4-section structure (add MCP, paste one-liner, test, troubleshoot). Exports `ONE_LINER` so the test asserts source-of-truth.
- `pages/__tests__/Connect.test.tsx` (new, 5 tests) — tabs default selection, switching, copy button writes exact `ONE_LINER`, provider-neutral header.
- `pages/Landing.tsx` — provider-neutral prose, CTAs, chrome label
- `pages/Home.tsx`, `pages/Patterns.tsx`, `pages/McpAuth.tsx`, `pages/Privacy.tsx` — banner / empty-state / error strings
- `components/Layout.tsx` — sidebar item `Connect to Claude` → `Connect`

**Docs / config**
- `README.md` — provider-neutral tagline + link to new Setup guide
- `docs/setup.md` (new, 110 lines) — three client sections mirroring on-page tabs
- `docs/kindred-prd-dd.md` — provider-neutral summary, `/connect` row, principles; ASCII architecture diagram updated from `Claude.ai (host)` to `MCP client (Claude / ChatGPT / Gemini / …)`
- `web/backend/routes/connect.py`, `.env.example` — provider-neutral comments

Total: 16 files, +486/-54 lines.

## Acceptance Criteria

- [x] No Claude-specific language in user-facing copy (Landing, Connect sidebar, Home banner, Patterns banner, McpAuth, Privacy except sub-processor example)
- [x] `/connect` shows three tabs (Claude Projects, ChatGPT, Gemini Gems) each with the same 4-section structure
- [x] Copy button writes the exact `ONE_LINER` string (covered by test)
- [x] `kindred://guide` MCP resource registered and resolves to `prompts/kindred-guide.md`
- [x] `docs/setup.md` exists with three client sections
- [x] README tagline mentions multiple clients
- [x] Adding a fourth client = appending to `CLIENTS` array (no JSX changes)
- [x] No regressions in existing tests

## Validation

| Check | Result |
|-------|--------|
| `npm run typecheck` (web/frontend) | ✅ |
| `npm run lint` (web/frontend) | ✅ |
| `npm test -- --run` (web/frontend) | ✅ 19 tests passed (5 new Connect tests) |
| `npm run build` (web/frontend) | ✅ |
| `ruff check .` (mcp) | ✅ |
| `mypy .` (mcp) | ✅ no issues, 10 source files |
| `pytest -q` (mcp) | ✅ 56 tests passed |
| `ruff check .` (web/backend) | ✅ |
| `mypy .` (web/backend) | ✅ no issues, 11 source files |
| `pytest -q` (web/backend) | ✅ 12 tests passed |
| NO_CLAUDE_GREP (Level 5) | ✅ Only documented carve-outs remain |

NO_CLAUDE_GREP carve-outs (all intentional): README enumerates clients ("Claude Projects, ChatGPT, Gemini Gems"); Privacy.tsx sub-processor example; Connect.tsx Claude Projects tab + `CLIENTS` entry; PRD "e.g. Claude.ai" example references and multi-client enumerations.

## Test Plan

- [ ] Visit `/connect`, mint a token, switch between the three tabs, click copy on the one-liner
- [ ] Verify sidebar reads "Connect" (no "Claude")
- [ ] Verify Landing CTA copy is provider-neutral
- [ ] Connect an MCP client and confirm `kindred://guide` resource is discoverable and returns the guide content
- [ ] Skim README and `docs/setup.md` end-to-end as a ChatGPT-only user

## Deviations from Plan

- PRD architecture diagram updated beyond planned line list (host box `Claude.ai (host)` → `MCP client (Claude / ChatGPT / Gemini / …)`) to keep the diagram consistent with the surrounding provider-neutral prose.
- `Connect.tsx` exports `ONE_LINER` so tests assert the source-of-truth string instead of duplicating the literal.
- Visual browser check skipped — no interactive browser available; production build and full test suite verified instead (declared rather than claimed, per plan guidance).
- PRD `claude` grep count is 8 (target was ≤ 4); all 8 are deliberate "e.g." examples or multi-client enumerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)