### PR TITLE
fix(web): reset body type on section.hero to prevent serif cascade

### DIFF
--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -513,6 +513,7 @@ section { padding: var(--sp-9) var(--sp-6); }
    Hero
    ============================================================ */
 .hero { padding: var(--sp-8) var(--sp-6) var(--sp-9); position: relative; overflow: hidden; }
+section.hero { font-family: var(--font-body); font-size: var(--fs-md); letter-spacing: normal; line-height: var(--lh-normal); }
 .hero-grid {
   max-width: 1120px; margin: 0 auto;
   display: grid; grid-template-columns: 1.15fr 1fr; gap: var(--sp-8);


### PR DESCRIPTION
The .hero typography utility class (display serif, tight tracking) was cascading into all body copy inside the landing Hero section. Add section.hero reset so the section acts as a layout container, not a type utility.

🤖 Generated with Claude Code