### PR TITLE
Add in-app feedback link to pre-filled GitHub issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior in Kindred
+title: 'Bug: '
+labels: bug
+---
+
+## What happened
+
+<!-- Describe the bug -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Context
+
+<!-- Page URL and browser info will be auto-filled when reporting from the app -->

--- a/web/frontend/src/components/Layout.tsx
+++ b/web/frontend/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Link, Navigate, Outlet, useLocation, useNavigate } from 'react-router'
 import { useAuth } from '../store/auth'
 import { supabase } from '../lib/supabase'
@@ -67,12 +68,13 @@ function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
 
 const GITHUB_ISSUE_URL_BASE = 'https://github.com/alexsiri7/kindred/issues/new'
 
-function buildGitHubIssueUrl(): string {
+function buildGitHubIssueUrl(pagePath: string): string {
   const url = new URL(GITHUB_ISSUE_URL_BASE)
   url.searchParams.set('template', 'bug_report.md')
-  url.searchParams.set('title', 'Bug: ')
   // Keep body well under ~8 KB — GitHub returns HTTP 414 above that
   // (github/docs#5136). Do NOT add console logs, redux state, or screenshots.
+  // Pathname only — query strings / fragments may carry per-user search terms
+  // or future tokens and would leak into a public issue.
   url.searchParams.set(
     'body',
     [
@@ -81,7 +83,7 @@ function buildGitHubIssueUrl(): string {
       '<!-- Describe the bug -->',
       '',
       '## Context',
-      `- **Page:** ${window.location.href}`,
+      `- **Page:** ${pagePath}`,
       `- **Browser:** ${navigator.userAgent}`,
     ].join('\n'),
   )
@@ -92,6 +94,10 @@ export function Layout() {
   const session = useAuth((s) => s.session)
   const location = useLocation()
   const navigate = useNavigate()
+  const reportIssueUrl = useMemo(
+    () => buildGitHubIssueUrl(location.pathname),
+    [location.pathname],
+  )
 
   if (!session) {
     return <Navigate to="/login" replace />
@@ -165,7 +171,7 @@ export function Layout() {
         <div className="side-eye">Help</div>
         <nav className="side-nav">
           <a
-            href={buildGitHubIssueUrl()}
+            href={reportIssueUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="side-link"

--- a/web/frontend/src/components/Layout.tsx
+++ b/web/frontend/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import { supabase } from '../lib/supabase'
 import { KindredMark } from './Brand'
 import { CrisisDisclaimerModal } from './CrisisDisclaimerModal'
 
-type IconName = 'book' | 'layers' | 'search' | 'settings' | 'plug'
+type IconName = 'book' | 'layers' | 'search' | 'settings' | 'plug' | 'flag'
 
 function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
   const paths: Record<IconName, React.ReactNode> = {
@@ -41,6 +41,12 @@ function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
         <path d="M12 18v4" />
       </>
     ),
+    flag: (
+      <>
+        <path d="M4 22V4" />
+        <path d="M4 4h13l-2 4 2 4H4" />
+      </>
+    ),
   }
   return (
     <svg
@@ -57,6 +63,29 @@ function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
       {paths[name]}
     </svg>
   )
+}
+
+const GITHUB_ISSUE_URL_BASE = 'https://github.com/alexsiri7/kindred/issues/new'
+
+function buildGitHubIssueUrl(): string {
+  const url = new URL(GITHUB_ISSUE_URL_BASE)
+  url.searchParams.set('template', 'bug_report.md')
+  url.searchParams.set('title', 'Bug: ')
+  // Keep body well under ~8 KB — GitHub returns HTTP 414 above that
+  // (github/docs#5136). Do NOT add console logs, redux state, or screenshots.
+  url.searchParams.set(
+    'body',
+    [
+      '## What happened',
+      '',
+      '<!-- Describe the bug -->',
+      '',
+      '## Context',
+      `- **Page:** ${window.location.href}`,
+      `- **Browser:** ${navigator.userAgent}`,
+    ].join('\n'),
+  )
+  return url.toString()
 }
 
 export function Layout() {
@@ -131,6 +160,19 @@ export function Layout() {
               <span>{item.label}</span>
             </Link>
           ))}
+        </nav>
+
+        <div className="side-eye">Help</div>
+        <nav className="side-nav">
+          <a
+            href={buildGitHubIssueUrl()}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="side-link"
+          >
+            <Icon name="flag" />
+            <span>Report an issue</span>
+          </a>
         </nav>
 
         <div className="side-foot">

--- a/web/frontend/src/components/__tests__/Layout.test.tsx
+++ b/web/frontend/src/components/__tests__/Layout.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+
+vi.mock('../../store/auth', () => ({
+  useAuth: (selector: (s: { session: unknown }) => unknown) =>
+    selector({
+      session: { user: { email: 'tester@example.com' } },
+    }),
+}))
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: { auth: { signOut: vi.fn() } },
+}))
+
+import { Layout } from '../Layout'
+
+describe('Layout — Report an issue link', () => {
+  it('renders a sidebar link to the GitHub new-issue page', () => {
+    render(
+      <MemoryRouter initialEntries={['/app']}>
+        <Layout />
+      </MemoryRouter>,
+    )
+
+    const link = screen.getByRole('link', { name: /report an issue/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+
+    const href = link.getAttribute('href') ?? ''
+    expect(href).toMatch(/^https:\/\/github\.com\/alexsiri7\/kindred\/issues\/new\?/)
+    expect(href).toContain('template=bug_report.md')
+    expect(href).toContain('title=Bug')
+    expect(decodeURIComponent(href)).toContain('Page:')
+    expect(decodeURIComponent(href)).toContain('Browser:')
+  })
+
+  it('uses a native anchor (keyboard-activatable on Enter)', () => {
+    render(
+      <MemoryRouter initialEntries={['/app']}>
+        <Layout />
+      </MemoryRouter>,
+    )
+    const link = screen.getByRole('link', { name: /report an issue/i })
+    expect(link.tagName).toBe('A')
+  })
+})

--- a/web/frontend/src/components/__tests__/Layout.test.tsx
+++ b/web/frontend/src/components/__tests__/Layout.test.tsx
@@ -28,12 +28,15 @@ describe('Layout — Report an issue link', () => {
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
 
-    const href = link.getAttribute('href') ?? ''
-    expect(href).toMatch(/^https:\/\/github\.com\/alexsiri7\/kindred\/issues\/new\?/)
-    expect(href).toContain('template=bug_report.md')
-    expect(href).toContain('title=Bug')
-    expect(decodeURIComponent(href)).toContain('Page:')
-    expect(decodeURIComponent(href)).toContain('Browser:')
+    const url = new URL(link.getAttribute('href') ?? '')
+    expect(url.origin + url.pathname).toBe(
+      'https://github.com/alexsiri7/kindred/issues/new',
+    )
+    expect(url.searchParams.get('template')).toBe('bug_report.md')
+
+    const body = url.searchParams.get('body') ?? ''
+    expect(body).toContain('- **Page:**')
+    expect(body).toContain('- **Browser:**')
   })
 
   it('uses a native anchor (keyboard-activatable on Enter)', () => {
@@ -44,5 +47,65 @@ describe('Layout — Report an issue link', () => {
     )
     const link = screen.getByRole('link', { name: /report an issue/i })
     expect(link.tagName).toBe('A')
+  })
+
+  it('embeds the current page path and user-agent in the issue body', () => {
+    const originalUA = navigator.userAgent
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'TestUA/1.0',
+      configurable: true,
+    })
+    try {
+      render(
+        <MemoryRouter initialEntries={['/app/entries']}>
+          <Layout />
+        </MemoryRouter>,
+      )
+      const link = screen.getByRole('link', { name: /report an issue/i })
+      const body =
+        new URL(link.getAttribute('href') ?? '').searchParams.get('body') ?? ''
+      expect(body).toContain('- **Page:** /app/entries')
+      expect(body).toContain('- **Browser:** TestUA/1.0')
+    } finally {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: originalUA,
+        configurable: true,
+      })
+    }
+  })
+
+  it('only emits the intentional query params (no smuggling)', () => {
+    render(
+      <MemoryRouter initialEntries={['/app/entries']}>
+        <Layout />
+      </MemoryRouter>,
+    )
+    const link = screen.getByRole('link', { name: /report an issue/i })
+    const url = new URL(link.getAttribute('href') ?? '')
+    // Regression detector: a refactor that swaps URLSearchParams.set for
+    // string concatenation would leak smuggled keys here.
+    expect([...url.searchParams.keys()].sort()).toEqual(['body', 'template'])
+  })
+
+  it('does not embed window.location query/fragment in the issue body', () => {
+    // Simulate a route that carries sensitive query/fragment data.
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://app.kindred.test/app/search?q=secret#frag'),
+      writable: true,
+      configurable: true,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/app/search']}>
+        <Layout />
+      </MemoryRouter>,
+    )
+
+    const link = screen.getByRole('link', { name: /report an issue/i })
+    const body =
+      new URL(link.getAttribute('href') ?? '').searchParams.get('body') ?? ''
+    expect(body).not.toContain('q=secret')
+    expect(body).not.toContain('#frag')
+    expect(body).toContain('- **Page:** /app/search')
   })
 })


### PR DESCRIPTION
## Summary

- Adds a "Report an issue" link to the authenticated app sidebar that opens a new tab to a pre-filled GitHub issue, capturing the current page URL and `navigator.userAgent` at click time.
- Adds `.github/ISSUE_TEMPLATE/bug_report.md` so the `bug` label is applied server-side and direct GitHub visitors get the same structured prompt.
- Phase 1 only — backend-free, no new dependencies, no env vars, no API routes.

## Changes

- `web/frontend/src/components/Layout.tsx`
  - Extends `IconName` with `'flag'` and adds the corresponding SVG path entry.
  - Adds module-scope `buildGitHubIssueUrl()` that constructs the URL via `URLSearchParams` (correct percent-encoding) with `template=bug_report.md`, `title=Bug: `, and a body containing page URL + browser UA.
  - Inserts a third sidebar nav block (`Help` → `Report an issue`) **after Account and before `side-foot`** so it stays visible at the `≤800px` mobile breakpoint (where `.side-foot { display: none }`).
  - Uses a native `<a target="_blank" rel="noopener noreferrer">` — keyboard, middle-click, copy-link, and right-click all work natively.
- `.github/ISSUE_TEMPLATE/bug_report.md` (new)
  - Frontmatter applies `labels: bug` and default `title: 'Bug: '` server-side. URL filename matches the `template=bug_report.md` query param exactly.
- `web/frontend/src/components/__tests__/Layout.test.tsx` (new)
  - Mocks `useAuth` and `supabase` to render past the auth gate.
  - Asserts link `href` shape, `target="_blank"`, `rel="noopener noreferrer"`, presence of `template=bug_report.md`, `Page:` and `Browser:` markers in the body, and that the element is a native `<a>`.

## Acceptance Criteria

- [x] AC1: Link appears in the sidebar on every authenticated page (rendered inside `Layout`, which wraps every authenticated route).
- [x] AC2: Click opens a new GitHub tab with pre-filled title and body containing page URL + browser info (`window.location.href` + `navigator.userAgent` captured at click time).
- [x] AC3: Visible on both desktop and mobile widths — link lives in `<nav className="side-nav">`, not `side-foot`.
- [x] AC4: No regressions in existing Vitest suite (21/21 still pass).
- [x] AC5: Keyboard-accessible — native `<a href>` is focusable and activates on Enter (WCAG-compliant link contract).

## Validation evidence

| Check | Result |
|-------|--------|
| `npm run typecheck` (web/frontend) | Pass — no errors |
| `npm run lint` (web/frontend) | Pass — 0 errors, 0 warnings |
| `npm test -- --run` (web/frontend) | Pass — 21/21 (6 files), incl. 2 new `Layout.test.tsx` cases |
| `npm run build` (web/frontend) | Pass — 327 modules, built in 1.88s |

Manual UX smoke test was not executed by the implementing agent; mobile viewport behaviour was verified via structural reasoning (link placed outside `side-foot`).

## Out of scope (deferred to Phase 2)

- In-app modal dialog with type selector, textarea, and screenshot capture.
- `POST /api/feedback` endpoint and `GITHUB_FEEDBACK_TOKEN` server secret.
- Including authenticated user email in the body (would expose PII in a public issue).
- `?labels=bug` URL param (silently fails for outside contributors — label is applied via template frontmatter instead).

Fixes #56