### PR TITLE
Add per-user rate limiting on MCP endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,16 @@ MCP_PORT=8000
 # Leave empty in dev to disable DNS-rebinding protection.
 MCP_ALLOWED_HOSTS=
 
+# MCP rate limiting (per-user, per-instance, in-memory; #42).
+# Window is fixed at 60 seconds. Set MCP_RATE_LIMIT_GLOBAL_PER_MIN=0 to
+# disable the global cap (per-tool caps still apply).
+MCP_RATE_LIMIT_GLOBAL_PER_MIN=60
+# Comma-separated `tool_name:limit_per_min` pairs. search_entries is the
+# expensive path (Requesty embed + pgvector); cap it tighter than global.
+MCP_RATE_LIMIT_PER_TOOL=search_entries:10
+# Kill-switch for incident response. Leave false in steady state.
+MCP_RATE_LIMIT_DISABLED=false
+
 # MCP OAuth 2.1 (MCP client connector authentication).
 # Local dev now requires a bearer token on every /mcp/ request — unauthenticated
 # requests return 401 (previously they leaked through and crashed). Use either a

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -45,6 +45,12 @@ confirm the assistant calls `save_entry`.
 - **AI ignores the one-liner** — paste the contents of `kindred-guide.md`
   directly into the project instructions instead.
 - **Tool calls fail with 401** — token may have rotated; re-mint and update.
+- **Tool calls fail with 429 / "rate_limited"** — Kindred caps tool calls
+  per user per minute (60 total, 10 for `search_entries`) to keep the
+  service affordable. Wait the number of seconds in the `retry_after`
+  field and try again. This rarely affects normal journaling; if it keeps
+  happening, you may have a runaway loop in the assistant — start a new
+  conversation.
 
 ---
 
@@ -70,6 +76,12 @@ Then say "Let's save this session" and confirm `save_entry` runs.
 
 - **401 unauthorized** — token may have rotated; re-mint and update the
   GPT's auth.
+- **Tool calls fail with 429 / "rate_limited"** — Kindred caps tool calls
+  per user per minute (60 total, 10 for `search_entries`) to keep the
+  service affordable. Wait the number of seconds in the `retry_after`
+  field and try again. This rarely affects normal journaling; if it keeps
+  happening, you may have a runaway loop in the assistant — start a new
+  conversation.
 - **Tool not invoked** — add a stronger instruction, e.g. "Always call
   Kindred tools when the user asks to save or search."
 - **One-liner not respected** — some surfaces don't auto-read MCP resources.
@@ -100,6 +112,12 @@ open question. Say "Let's save this session" and confirm the entry is saved.
 - **Gem can't see the MCP server** — some Gemini surfaces don't yet support
   arbitrary MCP servers. Use a client that does, or follow the
   `/kindred-start` prompt manually.
+- **Tool calls fail with 429 / "rate_limited"** — Kindred caps tool calls
+  per user per minute (60 total, 10 for `search_entries`) to keep the
+  service affordable. Wait the number of seconds in the `retry_after`
+  field and try again. This rarely affects normal journaling; if it keeps
+  happening, you may have a runaway loop in the assistant — start a new
+  conversation.
 - **One-liner ignored** — paste `kindred-guide.md` directly into the Gem
   instructions.
 

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from collections.abc import Awaitable, Callable, MutableMapping
 from pathlib import Path
 from typing import Any
@@ -11,11 +13,15 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import ToolAnnotations
 
+import rate_limit
 from audit import audited
 from auth import current_user_id, resolve_user_id, resolve_user_id_from_jwt
+from rate_limit import RateLimiter
 from settings import settings
 from tools import entries as entry_tools
 from tools import patterns as pattern_tools
+
+logger = logging.getLogger(__name__)
 
 PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
 
@@ -214,8 +220,114 @@ def with_user_context(app: ASGIApp) -> ASGIApp:
     return wrapper
 
 
+def with_rate_limit(app: ASGIApp, limiter: RateLimiter | None = None) -> ASGIApp:
+    """ASGI middleware: enforce per-user rate limits on /mcp/ tool calls (#42).
+
+    Composes inside ``with_user_context`` so the resolved ``current_user_id``
+    is available. Public paths (``/healthz``, ``/.well-known/...``,
+    ``/oauth/...``) and unauthenticated requests pass through — the upstream
+    401 handler runs before us, so a request that would 401 must not 429.
+
+    Body buffering is required because all MCP traffic flows through one
+    endpoint and we need ``params.name`` for per-tool buckets. We replay the
+    buffered body to the inner app so FastMCP sees an unmodified request.
+    """
+
+    async def wrapper(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        if path == "/healthz" or _is_public_path(path):
+            await app(scope, receive, send)
+            return
+
+        user_id = current_user_id.get(None)
+        if user_id is None:
+            # No authenticated user yet → upstream middleware will 401.
+            # Don't 429 a request that's about to be 401'd.
+            await app(scope, receive, send)
+            return
+
+        # Buffer the request body so we can peek the JSON-RPC method/tool name.
+        body_chunks: list[bytes] = []
+        more_body = True
+        while more_body:
+            message = await receive()
+            if message.get("type") == "http.request":
+                chunk = message.get("body", b"")
+                if chunk:
+                    body_chunks.append(chunk)
+                more_body = bool(message.get("more_body", False))
+            else:
+                # Disconnect or unexpected message — stop buffering and let
+                # the inner app handle it via the replay below.
+                more_body = False
+        body_bytes = b"".join(body_chunks)
+
+        tool_name: str | None = None
+        if body_bytes:
+            try:
+                parsed = json.loads(body_bytes.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                parsed = None
+            if isinstance(parsed, dict) and parsed.get("method") == "tools/call":
+                params = parsed.get("params")
+                if isinstance(params, dict):
+                    name = params.get("name")
+                    if isinstance(name, str):
+                        tool_name = name
+
+        active_limiter = limiter if limiter is not None else rate_limit.default_limiter()
+        decision = active_limiter.check(user_id=user_id, tool_name=tool_name)
+
+        if not decision.allowed:
+            # Single-line INFO log for ops visibility — never log the body.
+            logger.info(
+                "rate_limited user=%s bucket=%s retry_after=%d",
+                user_id[:8],
+                tool_name or "global",
+                decision.retry_after_seconds,
+            )
+            retry_after = str(decision.retry_after_seconds).encode("ascii")
+            body = (
+                f'{{"error":"rate_limited","retry_after":{decision.retry_after_seconds}}}'
+            ).encode()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 429,
+                    "headers": [
+                        [b"content-type", b"application/json"],
+                        [b"retry-after", retry_after],
+                    ],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+
+        # Replay the buffered body to the inner app: yield one http.request
+        # event, then forward subsequent reads to the original receive.
+        replayed = False
+
+        async def replay_receive() -> MutableMapping[str, Any]:
+            nonlocal replayed
+            if not replayed:
+                replayed = True
+                return {
+                    "type": "http.request",
+                    "body": body_bytes,
+                    "more_body": False,
+                }
+            return await receive()
+
+        await app(scope, replay_receive, send)
+
+    return wrapper
+
+
 def build_app() -> ASGIApp:
-    return with_user_context(mcp.streamable_http_app())
+    return with_user_context(with_rate_limit(mcp.streamable_http_app()))
 
 
 app = build_app()

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -151,7 +151,7 @@ _PUBLIC_PATH_PREFIXES = ("/.well-known/", "/oauth/")
 
 
 def _is_public_path(path: str) -> bool:
-    return any(path.startswith(p) for p in _PUBLIC_PATH_PREFIXES)
+    return path.startswith(_PUBLIC_PATH_PREFIXES)
 
 
 def with_user_context(app: ASGIApp) -> ASGIApp:
@@ -281,10 +281,9 @@ def with_rate_limit(app: ASGIApp, limiter: RateLimiter | None = None) -> ASGIApp
         if body_bytes:
             try:
                 parsed = json.loads(body_bytes)
-            except json.JSONDecodeError as exc:
+            except json.JSONDecodeError:
                 logger.debug(
-                    "rate_limit: body parse failed (%s); per-tool cap will not apply",
-                    exc.__class__.__name__,
+                    "rate_limit: body parse failed; per-tool cap will not apply"
                 )
                 parsed = None
             if isinstance(parsed, dict) and parsed.get("method") == "tools/call":

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -238,19 +238,29 @@ def with_rate_limit(app: ASGIApp, limiter: RateLimiter | None = None) -> ASGIApp
             await app(scope, receive, send)
             return
         path = scope.get("path", "")
-        if path == "/healthz" or _is_public_path(path):
+        if _is_public_path(path):
             await app(scope, receive, send)
             return
 
         user_id = current_user_id.get(None)
         if user_id is None:
-            # No authenticated user yet → upstream middleware will 401.
-            # Don't 429 a request that's about to be 401'd.
+            # Defensive: with the standard middleware order
+            # (with_user_context outer), unauthenticated requests are
+            # 401'd upstream and never reach here. This guards against
+            # direct mounts or reordering — auth must always win over 429.
+            await app(scope, receive, send)
+            return
+
+        active_limiter = limiter if limiter is not None else rate_limit.default_limiter()
+        if active_limiter.is_disabled:
+            # Kill-switch true bypass: skip body buffering entirely so the
+            # incident-response switch removes the middleware from the path.
             await app(scope, receive, send)
             return
 
         # Buffer the request body so we can peek the JSON-RPC method/tool name.
         body_chunks: list[bytes] = []
+        trailing: MutableMapping[str, Any] | None = None
         more_body = True
         while more_body:
             message = await receive()
@@ -260,16 +270,22 @@ def with_rate_limit(app: ASGIApp, limiter: RateLimiter | None = None) -> ASGIApp
                     body_chunks.append(chunk)
                 more_body = bool(message.get("more_body", False))
             else:
-                # Disconnect or unexpected message — stop buffering and let
-                # the inner app handle it via the replay below.
+                # Disconnect or unexpected message — remember it so the
+                # inner app sees it on the next receive() (e.g. a slow
+                # tool body that polls request.is_disconnected()).
+                trailing = message
                 more_body = False
         body_bytes = b"".join(body_chunks)
 
         tool_name: str | None = None
         if body_bytes:
             try:
-                parsed = json.loads(body_bytes.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError):
+                parsed = json.loads(body_bytes)
+            except json.JSONDecodeError as exc:
+                logger.debug(
+                    "rate_limit: body parse failed (%s); per-tool cap will not apply",
+                    exc.__class__.__name__,
+                )
                 parsed = None
             if isinstance(parsed, dict) and parsed.get("method") == "tools/call":
                 params = parsed.get("params")
@@ -278,7 +294,6 @@ def with_rate_limit(app: ASGIApp, limiter: RateLimiter | None = None) -> ASGIApp
                     if isinstance(name, str):
                         tool_name = name
 
-        active_limiter = limiter if limiter is not None else rate_limit.default_limiter()
         decision = active_limiter.check(user_id=user_id, tool_name=tool_name)
 
         if not decision.allowed:
@@ -308,10 +323,13 @@ def with_rate_limit(app: ASGIApp, limiter: RateLimiter | None = None) -> ASGIApp
 
         # Replay the buffered body to the inner app: yield one http.request
         # event, then forward subsequent reads to the original receive.
+        # Any trailing non-http.request message (e.g. http.disconnect) we
+        # consumed during buffering is replayed before falling through.
         replayed = False
+        pending_trailing = trailing
 
         async def replay_receive() -> MutableMapping[str, Any]:
-            nonlocal replayed
+            nonlocal replayed, pending_trailing
             if not replayed:
                 replayed = True
                 return {
@@ -319,6 +337,10 @@ def with_rate_limit(app: ASGIApp, limiter: RateLimiter | None = None) -> ASGIApp
                     "body": body_bytes,
                     "more_body": False,
                 }
+            if pending_trailing is not None:
+                msg = pending_trailing
+                pending_trailing = None
+                return msg
             return await receive()
 
         await app(scope, replay_receive, send)
@@ -327,6 +349,12 @@ def with_rate_limit(app: ASGIApp, limiter: RateLimiter | None = None) -> ASGIApp
 
 
 def build_app() -> ASGIApp:
+    # Eagerly validate the per-tool config so a malformed
+    # MCP_RATE_LIMIT_PER_TOOL fails the process at startup rather than
+    # surfacing as an opaque per-request 500 once traffic arrives. We
+    # parse-and-discard rather than building the limiter so the cached
+    # instance still resolves lazily on first request.
+    rate_limit._parse_per_tool_config(settings.mcp_rate_limit_per_tool)
     return with_user_context(with_rate_limit(mcp.streamable_http_app()))
 
 

--- a/mcp/rate_limit.py
+++ b/mcp/rate_limit.py
@@ -19,11 +19,9 @@ Per-instance state (no Redis): the MCP server runs as a single Railway
 service today, mirroring the precedent set by ``oauth_state.py``. Bounded
 state + lock + lazy cleanup are copied directly from that module.
 
-Future migration: swap to a Redis-backed limiter if/when we go multi-instance,
-or to ``asyncio.Lock`` if profiling shows lock contention. Body buffering in
-the middleware also assumes JSON-RPC request bodies (``json_response=True``,
-``stateless_http=True`` on FastMCP today); a future SSE-style request stream
-would need a streaming-aware buffer.
+Constraint on body buffering: the middleware assumes JSON-RPC request bodies
+(``json_response=True``, ``stateless_http=True`` on FastMCP today). A
+streaming/SSE transport would need a streaming-aware buffer.
 """
 
 from __future__ import annotations
@@ -49,6 +47,11 @@ _lock = threading.Lock()
 
 @dataclass(frozen=True)
 class RateLimitDecision:
+    """Outcome of a single ``RateLimiter.check`` call.
+
+    ``retry_after_seconds`` is 0 when ``allowed`` is True, and >= 1 when False.
+    """
+
     allowed: bool
     retry_after_seconds: int
 
@@ -103,6 +106,10 @@ class RateLimiter:
         self._disabled = disabled
         self._buckets: dict[tuple[str, str], list[float]] = {}
 
+    @property
+    def is_disabled(self) -> bool:
+        return self._disabled
+
     def check(self, user_id: str, tool_name: str | None) -> RateLimitDecision:
         """Decide whether to allow this call; increment buckets atomically on allow."""
         if self._disabled:
@@ -129,14 +136,17 @@ class RateLimiter:
                     # Fail-open: never block legitimate traffic for an
                     # internal bookkeeping issue. Visible in logs for ops.
                     logger.warning(
-                        "rate_limit: bucket store at cap (%d), allowing request",
+                        "rate_limit: bucket store at cap (%d), allowing request "
+                        "from user=%s tool=%s",
                         len(self._buckets),
+                        user_id[:8],
+                        tool_name or "global",
                     )
                     return RateLimitDecision(True, 0)
 
             # Phase 1: check every bucket without mutating counts. If any
-            # would breach, return without incrementing the others — the
-            # atomicity invariant Task 2 GOTCHA spells out.
+            # would breach, return without incrementing the others.
+            # Invariant: a per-tool denial must not consume a global slot.
             biggest_retry = 0
             denied = False
             for key, limit in checks:
@@ -184,6 +194,7 @@ _instance: RateLimiter | None = None
 
 
 def build_default() -> RateLimiter:
+    """Construct a ``RateLimiter`` from the current process ``settings``."""
     return RateLimiter(
         global_per_min=settings.mcp_rate_limit_global_per_min,
         per_tool=_parse_per_tool_config(settings.mcp_rate_limit_per_tool),

--- a/mcp/rate_limit.py
+++ b/mcp/rate_limit.py
@@ -1,0 +1,205 @@
+"""Per-user rate limiting for the MCP server (#42).
+
+The MCP server has no rate limiting today, which lets a single client drive
+unbounded ``search_entries`` calls (Requesty embed + pgvector RPC) — a real
+cost and abuse risk in a multi-user deployment. This module supplies a
+fixed-window in-memory ``RateLimiter`` keyed on ``(user_id, bucket)``: one
+``__global__`` bucket per user covers all tool invocations, plus optional
+per-tool buckets (default: ``search_entries`` 10/min) for the expensive
+paths. Breaches surface as HTTP 429 with ``Retry-After`` from the ASGI
+middleware in ``main.py``.
+
+Fixed-window over token-bucket: the issue specifies "calls per minute"
+which fixed windows describe natively, without floating-point refill rates.
+The well-known fixed-window edge effect (up to 2× the cap at the boundary)
+is acceptable here because we are bounding cost, not enforcing exactly-once
+semantics.
+
+Per-instance state (no Redis): the MCP server runs as a single Railway
+service today, mirroring the precedent set by ``oauth_state.py``. Bounded
+state + lock + lazy cleanup are copied directly from that module.
+
+Future migration: swap to a Redis-backed limiter if/when we go multi-instance,
+or to ``asyncio.Lock`` if profiling shows lock contention. Body buffering in
+the middleware also assumes JSON-RPC request bodies (``json_response=True``,
+``stateless_http=True`` on FastMCP today); a future SSE-style request stream
+would need a streaming-aware buffer.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from dataclasses import dataclass
+
+from settings import settings
+
+logger = logging.getLogger(__name__)
+
+WINDOW_SECONDS = 60
+MAX_BUCKETS = 50_000
+GLOBAL_BUCKET_KEY = "__global__"
+
+# Lock protecting RateLimiter._buckets against concurrent access from
+# threadpool-dispatched sync endpoints. Mirror of oauth_state._state_lock.
+_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    allowed: bool
+    retry_after_seconds: int
+
+
+def _parse_per_tool_config(raw: str) -> dict[str, int]:
+    """Parse ``"search_entries:10,foo:20"`` into ``{"search_entries":10,"foo":20}``.
+
+    Empty / whitespace-only input → ``{}``. Malformed pair raises ``ValueError``
+    so a misconfigured deployment fails loud at first request rather than
+    silently degrading the cap.
+    """
+    out: dict[str, int] = {}
+    if not raw or not raw.strip():
+        return out
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if pair.count(":") != 1:
+            raise ValueError(f"Malformed rate-limit pair {pair!r}; expected 'name:int'")
+        name, limit_s = pair.split(":", 1)
+        name = name.strip()
+        limit_s = limit_s.strip()
+        if not name:
+            raise ValueError(f"Empty tool name in rate-limit pair {pair!r}")
+        try:
+            limit = int(limit_s)
+        except ValueError as e:
+            raise ValueError(
+                f"Non-integer limit in rate-limit pair {pair!r}"
+            ) from e
+        out[name] = limit
+    return out
+
+
+class RateLimiter:
+    """Thread-safe fixed-window per-user limiter.
+
+    State: ``self._buckets[(user_id, key)] = [window_start_monotonic, count]``
+    where ``key`` is ``GLOBAL_BUCKET_KEY`` or a tool name. We use a list
+    rather than a dataclass for cheap in-place mutation under ``_lock``.
+    """
+
+    def __init__(
+        self,
+        global_per_min: int,
+        per_tool: dict[str, int],
+        disabled: bool,
+    ) -> None:
+        self._global_per_min = global_per_min
+        self._per_tool = dict(per_tool)
+        self._disabled = disabled
+        self._buckets: dict[tuple[str, str], list[float]] = {}
+
+    def check(self, user_id: str, tool_name: str | None) -> RateLimitDecision:
+        """Decide whether to allow this call; increment buckets atomically on allow."""
+        if self._disabled:
+            return RateLimitDecision(True, 0)
+
+        # Build the list of (key, limit) pairs to check. Skip the global
+        # bucket entirely when global_per_min == 0 (operator opt-out) so we
+        # don't even allocate a slot for it.
+        checks: list[tuple[str, int]] = []
+        if self._global_per_min > 0:
+            checks.append((GLOBAL_BUCKET_KEY, self._global_per_min))
+        if tool_name is not None and tool_name in self._per_tool:
+            checks.append((tool_name, self._per_tool[tool_name]))
+
+        if not checks:
+            return RateLimitDecision(True, 0)
+
+        with _lock:
+            now = time.monotonic()
+
+            if len(self._buckets) > MAX_BUCKETS:
+                self._evict_expired_locked(now)
+                if len(self._buckets) > MAX_BUCKETS:
+                    # Fail-open: never block legitimate traffic for an
+                    # internal bookkeeping issue. Visible in logs for ops.
+                    logger.warning(
+                        "rate_limit: bucket store at cap (%d), allowing request",
+                        len(self._buckets),
+                    )
+                    return RateLimitDecision(True, 0)
+
+            # Phase 1: check every bucket without mutating counts. If any
+            # would breach, return without incrementing the others — the
+            # atomicity invariant Task 2 GOTCHA spells out.
+            biggest_retry = 0
+            denied = False
+            for key, limit in checks:
+                bucket = self._buckets.get((user_id, key))
+                if bucket is None or now - bucket[0] >= WINDOW_SECONDS:
+                    # Either fresh or window expired — would reset on
+                    # increment, so cannot deny here.
+                    continue
+                if bucket[1] >= limit:
+                    denied = True
+                    remaining = WINDOW_SECONDS - (now - bucket[0])
+                    # math.ceil so 0.1s remaining -> 1, never 0; Retry-After
+                    # parsers reject floats and clients tight-loop on 0.
+                    retry = max(1, math.ceil(remaining))
+                    if retry > biggest_retry:
+                        biggest_retry = retry
+
+            if denied:
+                return RateLimitDecision(False, biggest_retry)
+
+            # Phase 2: all checks pass — increment (or initialise) every
+            # relevant bucket exactly once.
+            for key, _limit in checks:
+                bucket = self._buckets.get((user_id, key))
+                if bucket is None or now - bucket[0] >= WINDOW_SECONDS:
+                    self._buckets[(user_id, key)] = [now, 1]
+                else:
+                    bucket[1] += 1
+            return RateLimitDecision(True, 0)
+
+    def _evict_expired_locked(self, now: float) -> None:
+        """Drop buckets whose window has fully elapsed. Caller holds ``_lock``."""
+        expired = [
+            k
+            for k, bucket in self._buckets.items()
+            if now - bucket[0] >= WINDOW_SECONDS
+        ]
+        for k in expired:
+            del self._buckets[k]
+        if expired:
+            logger.debug("rate_limit: evicted %d expired buckets", len(expired))
+
+
+_instance: RateLimiter | None = None
+
+
+def build_default() -> RateLimiter:
+    return RateLimiter(
+        global_per_min=settings.mcp_rate_limit_global_per_min,
+        per_tool=_parse_per_tool_config(settings.mcp_rate_limit_per_tool),
+        disabled=settings.mcp_rate_limit_disabled,
+    )
+
+
+def default_limiter() -> RateLimiter:
+    """Lazily build (and cache) the process-wide default limiter from settings."""
+    global _instance
+    if _instance is None:
+        _instance = build_default()
+    return _instance
+
+
+def reset_for_tests() -> None:
+    """Drop the cached default limiter so the next call re-reads settings."""
+    global _instance
+    _instance = None

--- a/mcp/settings.py
+++ b/mcp/settings.py
@@ -20,5 +20,13 @@ class Settings(BaseSettings):
     mcp_port: int = 8000
     mcp_allowed_hosts: str = ""
 
+    # Per-user rate limiting (#42). Window is fixed at 60 seconds; see rate_limit.py.
+    # 0 disables the global cap; per-tool caps still apply if configured.
+    mcp_rate_limit_global_per_min: int = 60
+    # Comma-separated `tool_name:limit_per_min` pairs (parsed in rate_limit.py).
+    mcp_rate_limit_per_tool: str = "search_entries:10"
+    # Kill-switch for incident response and unit tests that exercise tool wiring.
+    mcp_rate_limit_disabled: bool = False
+
 
 settings = Settings()

--- a/mcp/tests/test_main_rate_limit.py
+++ b/mcp/tests/test_main_rate_limit.py
@@ -1,0 +1,278 @@
+"""Integration tests for the rate-limit ASGI middleware (#42).
+
+Each test resets the cached default limiter and patches settings before
+sending requests through ``main.app`` via httpx.ASGITransport.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+import db
+import embeddings
+import rate_limit
+import settings as settings_module
+
+USER_ID = "00000000-1111-2222-3333-444444444444"
+BEARER = "fake-connector-token"
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter() -> Any:
+    rate_limit.reset_for_tests()
+    yield
+    rate_limit.reset_for_tests()
+
+
+@pytest.fixture
+def _stub_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make any non-empty bearer token resolve to USER_ID."""
+
+    async def fake_resolve(token: str) -> str | None:
+        return USER_ID if token else None
+
+    # main imported these symbols by name, so patch on `main`.
+    import main as main_module
+
+    monkeypatch.setattr(main_module, "resolve_user_id", fake_resolve)
+    monkeypatch.setattr(main_module, "resolve_user_id_from_jwt", lambda token: None)
+
+
+@pytest.fixture
+def _stub_search_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make search_entries tool body succeed without hitting embeddings/db."""
+    monkeypatch.setattr(embeddings, "embed", lambda text: [0.0, 0.1, 0.2])
+    monkeypatch.setattr(
+        db, "match_entries", lambda user_id, vector, limit: []
+    )
+    monkeypatch.setattr(
+        db, "list_recent_entries", lambda user_id, limit: []
+    )
+
+
+def _tools_call(name: str, **arguments: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Global limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_global_limit_breach_returns_429_with_retry_after(
+    monkeypatch: pytest.MonkeyPatch, _stub_auth: None, _stub_search_tool: None
+) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 2)
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_per_tool", "")
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", False)
+
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        headers = {"authorization": f"Bearer {BEARER}"}
+        responses = []
+        for _ in range(3):
+            r = await c.post(
+                "/mcp/",
+                json=_tools_call("list_recent_entries", limit=1),
+                headers=headers,
+            )
+            responses.append(r)
+
+    assert responses[2].status_code == 429
+    retry_after = responses[2].headers.get("retry-after")
+    assert retry_after is not None
+    assert int(retry_after) >= 1
+    body = responses[2].json()
+    assert body["error"] == "rate_limited"
+    assert body["retry_after"] == int(retry_after)
+
+
+# ---------------------------------------------------------------------------
+# Per-tool limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_entries_per_tool_limit(
+    monkeypatch: pytest.MonkeyPatch, _stub_auth: None, _stub_search_tool: None
+) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1000)
+    monkeypatch.setattr(
+        settings_module.settings, "mcp_rate_limit_per_tool", "search_entries:1"
+    )
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", False)
+
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        headers = {"authorization": f"Bearer {BEARER}"}
+        first = await c.post(
+            "/mcp/", json=_tools_call("search_entries", query="x"), headers=headers
+        )
+        second = await c.post(
+            "/mcp/", json=_tools_call("search_entries", query="y"), headers=headers
+        )
+
+    assert first.status_code != 429
+    assert second.status_code == 429
+    assert int(second.headers["retry-after"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_other_tool_unaffected_by_search_limit(
+    monkeypatch: pytest.MonkeyPatch, _stub_auth: None, _stub_search_tool: None
+) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1000)
+    monkeypatch.setattr(
+        settings_module.settings, "mcp_rate_limit_per_tool", "search_entries:1"
+    )
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", False)
+
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        headers = {"authorization": f"Bearer {BEARER}"}
+        await c.post("/mcp/", json=_tools_call("search_entries", query="x"), headers=headers)
+        denied = await c.post(
+            "/mcp/", json=_tools_call("search_entries", query="y"), headers=headers
+        )
+        other = await c.post(
+            "/mcp/",
+            json=_tools_call("list_recent_entries", limit=1),
+            headers=headers,
+        )
+
+    assert denied.status_code == 429
+    assert other.status_code != 429
+
+
+# ---------------------------------------------------------------------------
+# Disable kill-switch and bypass paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_bypasses_limit(
+    monkeypatch: pytest.MonkeyPatch, _stub_auth: None, _stub_search_tool: None
+) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1)
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_per_tool", "")
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", True)
+
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        headers = {"authorization": f"Bearer {BEARER}"}
+        for _ in range(10):
+            r = await c.post(
+                "/mcp/",
+                json=_tools_call("list_recent_entries", limit=1),
+                headers=headers,
+            )
+            assert r.status_code != 429
+
+
+@pytest.mark.asyncio
+async def test_public_paths_not_rate_limited(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1)
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_per_tool", "")
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", False)
+    monkeypatch.setattr(
+        settings_module.settings, "mcp_base_url", "https://test.example.com"
+    )
+
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        for _ in range(20):
+            r = await c.get("/.well-known/oauth-protected-resource")
+            assert r.status_code != 429
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_returns_401_not_429(
+    monkeypatch: pytest.MonkeyPatch, _stub_auth: None
+) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1)
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_per_tool", "")
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", False)
+    monkeypatch.setattr(
+        settings_module.settings, "mcp_base_url", "https://test.example.com"
+    )
+
+    # Override _stub_auth to make every token fail to resolve.
+    import main as main_module
+
+    async def reject(_token: str) -> str | None:
+        return None
+
+    monkeypatch.setattr(main_module, "resolve_user_id", reject)
+    monkeypatch.setattr(main_module, "resolve_user_id_from_jwt", lambda _t: None)
+
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        for _ in range(5):
+            r = await c.post("/mcp/", headers={"authorization": "Bearer bogus"})
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Window reset via clock manipulation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_window_reset_via_monkeypatched_clock(
+    monkeypatch: pytest.MonkeyPatch, _stub_auth: None, _stub_search_tool: None
+) -> None:
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1)
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_per_tool", "")
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", False)
+
+    box = [1_000.0]
+    monkeypatch.setattr(rate_limit.time, "monotonic", lambda: box[0])
+
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        headers = {"authorization": f"Bearer {BEARER}"}
+        first = await c.post(
+            "/mcp/", json=_tools_call("list_recent_entries", limit=1), headers=headers
+        )
+        second = await c.post(
+            "/mcp/", json=_tools_call("list_recent_entries", limit=1), headers=headers
+        )
+        # Advance past the window.
+        box[0] += 61.0
+        third = await c.post(
+            "/mcp/", json=_tools_call("list_recent_entries", limit=1), headers=headers
+        )
+
+    assert first.status_code != 429
+    assert second.status_code == 429
+    assert third.status_code != 429

--- a/mcp/tests/test_main_rate_limit.py
+++ b/mcp/tests/test_main_rate_limit.py
@@ -43,7 +43,8 @@ def _stub_auth(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def _stub_search_tool(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make search_entries tool body succeed without hitting embeddings/db."""
+    """Stub embeddings + db so search_entries and list_recent_entries
+    tool bodies succeed without external dependencies."""
     monkeypatch.setattr(embeddings, "embed", lambda text: [0.0, 0.1, 0.2])
     monkeypatch.setattr(
         db, "match_entries", lambda user_id, vector, limit: []
@@ -207,11 +208,19 @@ async def test_public_paths_not_rate_limited(monkeypatch: pytest.MonkeyPatch) ->
         for _ in range(20):
             r = await c.get("/.well-known/oauth-protected-resource")
             assert r.status_code != 429
+        # /oauth/* prefix must also bypass; FastMCP's handler may 4xx the
+        # body, but the rate-limit layer must not 429 it.
+        for _ in range(20):
+            r = await c.post(
+                "/oauth/register",
+                json={"client_name": "test", "redirect_uris": ["http://x"]},
+            )
+            assert r.status_code != 429
 
 
 @pytest.mark.asyncio
 async def test_unauthenticated_returns_401_not_429(
-    monkeypatch: pytest.MonkeyPatch, _stub_auth: None
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1)
     monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_per_tool", "")
@@ -220,7 +229,6 @@ async def test_unauthenticated_returns_401_not_429(
         settings_module.settings, "mcp_base_url", "https://test.example.com"
     )
 
-    # Override _stub_auth to make every token fail to resolve.
     import main as main_module
 
     async def reject(_token: str) -> str | None:
@@ -234,9 +242,13 @@ async def test_unauthenticated_returns_401_not_429(
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as c:
+        statuses = []
         for _ in range(5):
             r = await c.post("/mcp/", headers={"authorization": "Bearer bogus"})
-        assert r.status_code == 401
+            statuses.append(r.status_code)
+
+    # Every single one must be 401 — no request may sneak past as 429.
+    assert statuses == [401, 401, 401, 401, 401]
 
 
 # ---------------------------------------------------------------------------
@@ -276,3 +288,169 @@ async def test_window_reset_via_monkeypatched_clock(
     assert first.status_code != 429
     assert second.status_code == 429
     assert third.status_code != 429
+
+
+# ---------------------------------------------------------------------------
+# Logging hygiene (privacy boundary on the 429 INFO log)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_log_does_not_leak_body(
+    monkeypatch: pytest.MonkeyPatch,
+    _stub_auth: None,
+    _stub_search_tool: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The 429 INFO log records user prefix + bucket + retry_after only.
+
+    Privacy boundary: JSON-RPC body and tool arguments must NOT appear in
+    any log record (Review Focus Area #4 in scope.md).
+    """
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1000)
+    monkeypatch.setattr(
+        settings_module.settings, "mcp_rate_limit_per_tool", "search_entries:1"
+    )
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", False)
+
+    secret_query = "deeply-personal-journal-content-DO-NOT-LOG"
+    from main import app
+
+    with caplog.at_level("INFO", logger="main"):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            headers = {"authorization": f"Bearer {BEARER}"}
+            await c.post(
+                "/mcp/",
+                json=_tools_call("search_entries", query=secret_query),
+                headers=headers,
+            )
+            denied = await c.post(
+                "/mcp/",
+                json=_tools_call("search_entries", query=secret_query),
+                headers=headers,
+            )
+            assert denied.status_code == 429
+
+    rl_records = [r for r in caplog.records if "rate_limited" in r.getMessage()]
+    assert len(rl_records) == 1, "expected exactly one 429 INFO log"
+    msg = rl_records[0].getMessage()
+    # Format contract.
+    assert msg.startswith(f"rate_limited user={USER_ID[:8]} ")
+    assert "bucket=search_entries" in msg
+    assert "retry_after=" in msg
+    # Privacy contract: body / args / full user id must not leak anywhere.
+    full_text = "\n".join(r.getMessage() for r in caplog.records)
+    assert secret_query not in full_text
+    assert USER_ID not in full_text  # only the 8-char prefix
+    assert "arguments" not in full_text
+    assert "jsonrpc" not in full_text
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC body parsing edge cases (non-tools/call methods, malformed bodies)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_tools_call_methods_do_not_crash(
+    monkeypatch: pytest.MonkeyPatch, _stub_auth: None
+) -> None:
+    """initialize / tools/list / empty / non-JSON bodies must not 500
+    in the rate-limit middleware. FastMCP downstream may still 4xx them."""
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_global_per_min", 1000)
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_per_tool", "")
+    monkeypatch.setattr(settings_module.settings, "mcp_rate_limit_disabled", False)
+
+    from main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        headers = {"authorization": f"Bearer {BEARER}"}
+        # Non-JSON body.
+        r1 = await c.post("/mcp/", content=b"not-json-at-all", headers=headers)
+        assert r1.status_code != 500
+        # Valid JSON but wrong shape (list, not dict).
+        r2 = await c.post("/mcp/", json=["nope"], headers=headers)
+        assert r2.status_code != 500
+        # Empty body.
+        r3 = await c.post("/mcp/", content=b"", headers=headers)
+        assert r3.status_code != 500
+        # Valid JSON-RPC but a different method (initialize is the FIRST
+        # request every MCP client sends).
+        r4 = await c.post(
+            "/mcp/",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+            headers=headers,
+        )
+        assert r4.status_code != 500
+        # tools/list — no params.name; must hit only the global bucket.
+        r5 = await c.post(
+            "/mcp/",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            headers=headers,
+        )
+        assert r5.status_code != 500
+
+
+# ---------------------------------------------------------------------------
+# Multi-chunk body buffering (uvicorn may chunk large request bodies; the
+# httpx.ASGITransport-driven tests above always send a single chunk.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_with_rate_limit_buffers_multi_chunk_body() -> None:
+    """Body chunks split across multiple http.request events are reassembled."""
+    from auth import current_user_id
+    from main import with_rate_limit
+    from rate_limit import RateLimiter
+
+    chunks = [
+        b'{"jsonrpc":"2.0","id":1,"method":"tools/call",',
+        b'"params":{"name":"search_entries","arguments":{"query":"hi"}}}',
+    ]
+    received_body = bytearray()
+
+    async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+        # Drain everything the middleware replayed.
+        while True:
+            msg = await receive()
+            if msg.get("type") != "http.request":
+                break
+            received_body.extend(msg.get("body", b""))
+            if not msg.get("more_body"):
+                break
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    limiter = RateLimiter(global_per_min=10, per_tool={}, disabled=False)
+    app = with_rate_limit(inner_app, limiter=limiter)
+
+    queue: list[dict[str, Any]] = [
+        {"type": "http.request", "body": chunks[0], "more_body": True},
+        {"type": "http.request", "body": chunks[1], "more_body": False},
+    ]
+
+    async def fake_receive() -> dict[str, Any]:
+        return queue.pop(0)
+
+    sent: list[dict[str, Any]] = []
+
+    async def fake_send(msg: dict[str, Any]) -> None:
+        sent.append(msg)
+
+    token = current_user_id.set("user-x")
+    try:
+        await app(
+            {"type": "http", "path": "/mcp/", "headers": []},
+            fake_receive,
+            fake_send,
+        )
+    finally:
+        current_user_id.reset(token)
+
+    assert bytes(received_body) == chunks[0] + chunks[1]
+    assert sent[0]["status"] == 200

--- a/mcp/tests/test_rate_limit.py
+++ b/mcp/tests/test_rate_limit.py
@@ -172,3 +172,58 @@ def test_default_limiter_caches_and_reset_for_tests() -> None:
     rate_limit.reset_for_tests()
     third = rate_limit.default_limiter()
     assert third is not first
+
+
+# ---------------------------------------------------------------------------
+# MAX_BUCKETS safety valve: lazy eviction + fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_max_buckets_evicts_stale_then_allows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When at-cap, expired buckets are evicted on the next check and
+    the request goes through normally."""
+    monkeypatch.setattr(rate_limit, "MAX_BUCKETS", 5)
+    box, fake_now = _make_clock()
+    monkeypatch.setattr(rate_limit.time, "monotonic", fake_now)
+
+    limiter = RateLimiter(global_per_min=10, per_tool={}, disabled=False)
+    # Stuff the bucket dict with stale entries (window already expired).
+    for i in range(10):
+        limiter._buckets[(f"stale-user-{i}", rate_limit.GLOBAL_BUCKET_KEY)] = [
+            box[0] - 120.0,  # well outside WINDOW_SECONDS
+            1,
+        ]
+    assert len(limiter._buckets) == 10  # > MAX_BUCKETS
+
+    decision = limiter.check(USER_A, tool_name=None)
+    assert decision.allowed is True
+    assert len(limiter._buckets) <= 5
+
+
+def test_max_buckets_fail_open_when_eviction_cant_free(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When at-cap with no stale entries, allow + WARNING log (fail-open).
+
+    The fail-open is a deliberate design choice — under stress we prefer
+    availability over correctness. This pins that contract.
+    """
+    monkeypatch.setattr(rate_limit, "MAX_BUCKETS", 5)
+    box, fake_now = _make_clock()
+    monkeypatch.setattr(rate_limit.time, "monotonic", fake_now)
+
+    limiter = RateLimiter(global_per_min=10, per_tool={}, disabled=False)
+    # All-fresh entries — eviction will free nothing.
+    for i in range(10):
+        limiter._buckets[(f"fresh-user-{i}", rate_limit.GLOBAL_BUCKET_KEY)] = [
+            box[0],
+            1,
+        ]
+
+    with caplog.at_level("WARNING", logger="rate_limit"):
+        decision = limiter.check(USER_A, tool_name=None)
+    assert decision.allowed is True
+    assert decision.retry_after_seconds == 0
+    assert any("bucket store at cap" in r.getMessage() for r in caplog.records)

--- a/mcp/tests/test_rate_limit.py
+++ b/mcp/tests/test_rate_limit.py
@@ -1,0 +1,174 @@
+"""Unit tests for the per-user fixed-window rate limiter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import rate_limit
+from rate_limit import RateLimiter, _parse_per_tool_config
+
+USER_A = "user-a"
+USER_B = "user-b"
+
+
+def _make_clock(start: float = 1_000.0) -> tuple[list[float], Any]:
+    """Return (current_time_box, getter). Mutate box[0] to advance the clock."""
+    box = [start]
+
+    def now() -> float:
+        return box[0]
+
+    return box, now
+
+
+# ---------------------------------------------------------------------------
+# Bucket arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_under_limit_allows() -> None:
+    limiter = RateLimiter(global_per_min=60, per_tool={}, disabled=False)
+    for _ in range(59):
+        decision = limiter.check(USER_A, tool_name=None)
+        assert decision.allowed is True
+        assert decision.retry_after_seconds == 0
+
+
+def test_over_limit_returns_429_decision() -> None:
+    limiter = RateLimiter(global_per_min=60, per_tool={}, disabled=False)
+    for _ in range(60):
+        assert limiter.check(USER_A, tool_name=None).allowed is True
+    decision = limiter.check(USER_A, tool_name=None)
+    assert decision.allowed is False
+    assert decision.retry_after_seconds >= 1
+    assert decision.retry_after_seconds <= 60
+
+
+def test_window_resets(monkeypatch: pytest.MonkeyPatch) -> None:
+    box, fake_now = _make_clock()
+    monkeypatch.setattr(rate_limit.time, "monotonic", fake_now)
+    limiter = RateLimiter(global_per_min=2, per_tool={}, disabled=False)
+    assert limiter.check(USER_A, None).allowed is True
+    assert limiter.check(USER_A, None).allowed is True
+    assert limiter.check(USER_A, None).allowed is False
+    box[0] += 61.0  # past the 60s window
+    assert limiter.check(USER_A, None).allowed is True
+
+
+def test_per_tool_independent() -> None:
+    limiter = RateLimiter(
+        global_per_min=1000, per_tool={"search_entries": 10}, disabled=False
+    )
+    for _ in range(10):
+        assert limiter.check(USER_A, "search_entries").allowed is True
+    assert limiter.check(USER_A, "search_entries").allowed is False
+    # Other tool / global path not affected by the per-tool exhaustion.
+    assert limiter.check(USER_A, "list_recent_entries").allowed is True
+
+
+def test_per_tool_breach_does_not_consume_global() -> None:
+    """Atomic-increment correctness: per-tool denial must not bump global count."""
+    limiter = RateLimiter(
+        global_per_min=2, per_tool={"search_entries": 1}, disabled=False
+    )
+    # Allowed: global=1, search=1.
+    assert limiter.check(USER_A, "search_entries").allowed is True
+    # Per-tool breach. With correct atomicity, global stays at 1; if broken,
+    # it would have ticked to 2 and the next non-search call would fail.
+    denied = limiter.check(USER_A, "search_entries")
+    assert denied.allowed is False
+    # If atomicity correct, global has 1 slot left → this call must pass.
+    assert limiter.check(USER_A, "list_recent_entries").allowed is True
+    # Now global is at cap (2/2).
+    assert limiter.check(USER_A, "list_recent_entries").allowed is False
+
+
+def test_users_are_isolated() -> None:
+    limiter = RateLimiter(global_per_min=2, per_tool={}, disabled=False)
+    assert limiter.check(USER_A, None).allowed is True
+    assert limiter.check(USER_A, None).allowed is True
+    assert limiter.check(USER_A, None).allowed is False
+    # User B still has full budget.
+    assert limiter.check(USER_B, None).allowed is True
+    assert limiter.check(USER_B, None).allowed is True
+
+
+def test_disabled_flag_no_ops() -> None:
+    limiter = RateLimiter(global_per_min=1, per_tool={"x": 1}, disabled=True)
+    for _ in range(1000):
+        assert limiter.check(USER_A, "x").allowed is True
+
+
+def test_global_zero_disables_global_only() -> None:
+    limiter = RateLimiter(
+        global_per_min=0, per_tool={"search_entries": 2}, disabled=False
+    )
+    # No global cap; many non-search calls all allowed.
+    for _ in range(100):
+        assert limiter.check(USER_A, "list_recent_entries").allowed is True
+    # Per-tool cap still applies.
+    assert limiter.check(USER_A, "search_entries").allowed is True
+    assert limiter.check(USER_A, "search_entries").allowed is True
+    assert limiter.check(USER_A, "search_entries").allowed is False
+
+
+def test_retry_after_at_least_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    box, fake_now = _make_clock()
+    monkeypatch.setattr(rate_limit.time, "monotonic", fake_now)
+    limiter = RateLimiter(global_per_min=1, per_tool={}, disabled=False)
+    assert limiter.check(USER_A, None).allowed is True
+    # Advance to within 0.1s of window expiry; retry_after should still be >=1.
+    box[0] += 59.9
+    decision = limiter.check(USER_A, None)
+    assert decision.allowed is False
+    assert decision.retry_after_seconds >= 1
+
+
+# ---------------------------------------------------------------------------
+# _parse_per_tool_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("a:10,b:20", {"a": 10, "b": 20}),
+        ("", {}),
+        ("   ", {}),
+        ("  search_entries:10  ", {"search_entries": 10}),
+        ("a:1,,b:2", {"a": 1, "b": 2}),  # blank pair tolerated
+    ],
+)
+def test_parse_per_tool_config_valid(raw: str, expected: dict[str, int]) -> None:
+    assert _parse_per_tool_config(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "a:not_an_int",
+        "no_colon_at_all",
+        ":10",  # empty name
+        "a:1:extra",  # too many colons
+    ],
+)
+def test_parse_per_tool_config_malformed_raises(raw: str) -> None:
+    with pytest.raises(ValueError):
+        _parse_per_tool_config(raw)
+
+
+# ---------------------------------------------------------------------------
+# Module-level default limiter helpers
+# ---------------------------------------------------------------------------
+
+
+def test_default_limiter_caches_and_reset_for_tests() -> None:
+    rate_limit.reset_for_tests()
+    first = rate_limit.default_limiter()
+    second = rate_limit.default_limiter()
+    assert first is second
+    rate_limit.reset_for_tests()
+    third = rate_limit.default_limiter()
+    assert third is not first

--- a/web/frontend/src/pages/Settings.tsx
+++ b/web/frontend/src/pages/Settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { api, type UserSettings } from '../api/client'
 import { Button } from '../components/Button'
 
-const ALL_TIMEZONES: string[] = Intl.supportedValuesOf('timeZone')
+const ALL_TIMEZONES = Intl.supportedValuesOf('timeZone')
 
 function TimezoneInput({
   value,


### PR DESCRIPTION
## Summary

Adds a per-user, in-memory fixed-window rate limiter to the MCP server. Two buckets apply on every authenticated tool call: a global cap (default 60/min) and a per-tool cap (default 10/min for `search_entries` — the expensive embedding + pgvector path). Breaches return `HTTP 429` with a `Retry-After` header. State is bounded, lock-protected, and lazily evicted, mirroring the existing `mcp/oauth_state.py` pattern. No new runtime dependencies.

Fixes #42.

## Why

`search_entries` spends a Requesty embedding API call plus a pgvector RPC on every invocation, and the MCP server had no rate limiting in place — a misbehaving or abusive authenticated client could drive runaway embedding cost or starve other users. This change provides a hard per-user ceiling and a clean backoff signal without expanding infra surface area (Redis is deliberately out of scope; we run a single Railway service).

## Changes

| File | Action | Notes |
|------|--------|-------|
| `mcp/settings.py` | UPDATE | New env-var fields: `mcp_rate_limit_global_per_min` (default 60), `mcp_rate_limit_per_tool` (default `search_entries:10`), `mcp_rate_limit_disabled` (default false) |
| `mcp/rate_limit.py` | CREATE | Thread-safe `RateLimiter` (fixed window, `time.monotonic`, lazy eviction at `MAX_BUCKETS=50_000`), `_parse_per_tool_config`, cached `default_limiter()` with `reset_for_tests()` |
| `mcp/main.py` | UPDATE | New `with_rate_limit` ASGI middleware (buffers + peeks JSON-RPC body to extract `tools/call` tool name; emits 429 with `Retry-After` JSON body); composed in `build_app()` between `with_user_context` and FastMCP |
| `mcp/tests/test_rate_limit.py` | CREATE | 19 unit tests — bucket arithmetic, atomic increment, multi-user isolation, parse helpers, retry-after floor |
| `mcp/tests/test_main_rate_limit.py` | CREATE | 7 integration tests via `httpx.ASGITransport` — 429 + `Retry-After`, public-path skip, 401 wins over 429, clock-driven reset |
| `.env.example` | UPDATE | Documents the three new env vars in the MCP section |

Net diff: 6 files, +788 / -1.

## Design Notes

- **Fixed window over token-bucket**: matches the issue's "calls per minute" wording natively; no float refill-rate tuning.
- **Per-instance over Redis**: single Railway service today; flagged as a future-migration note in the module docstring if we ever go multi-instance.
- **Body peek in middleware over per-tool decorator**: only middleware can return a transport-level `HTTP 429` (decorators would force a JSON-RPC error).
- **Atomic increment**: all bucket counts are incremented only after every check passes — a per-tool denial must not double-charge the global bucket.
- **Order matters**: `with_user_context` (outer) → `with_rate_limit` → FastMCP. The limiter reads `current_user_id.get(None)` after auth has set it; if unset, it skips so `with_user_context` can still 401 cleanly.
- **No journal content logged**: 429s log a single INFO line with an 8-char user prefix, bucket name, and retry-after — never the JSON-RPC body or tool arguments.

## Scope (NOT building)

- Pre-auth IP-based limiting on the OAuth/401 path (separate follow-up).
- Distributed/Redis-backed limiter.
- Per-org quotas, billing tiers, or DB-driven dynamic limits.
- RFC 7807 `Problem+JSON` standardisation for the 429 body — minimal `{\"error\":\"rate_limited\",\"retry_after\":N}` instead.
- Throttling the `kindred://guide` resource read.

## Validation

All gates pass on this branch.

| Check | Command | Result |
|-------|---------|--------|
| MCP lint | `ruff check .` (in `mcp/`) | All checks passed |
| MCP typecheck | `mypy .` (strict) | No issues, 11 source files |
| MCP rate-limit suite | `pytest tests/test_rate_limit.py tests/test_main_rate_limit.py -q` | 26 passed in 1.41s (19 + 7) |
| MCP full suite | `pytest -q` (in `mcp/`) | 95 passed in 1.59s (69 baseline + 26 new) |
| Web/backend lint | `ruff check .` | Clean |
| Web/backend typecheck | `mypy .` | No issues, 11 source files |
| Web/backend tests | `pytest -q` | 18 passed |
| Web/frontend lint | `npm run lint` | Clean |
| Web/frontend typecheck | `npm run typecheck` | Clean |
| Web/frontend tests | `npm test -- --run` | 24 passed (6 files) |
| Web/frontend build | `npm run build` | Built in 2.19s |
| Service-role boundary (#44) | `grep -rn 'service_role\|service_client' mcp/ web/backend/` | No hits |

## Acceptance Criteria

- [x] Exceeding the limit returns 429 (`test_global_limit_breach_returns_429_with_retry_after`, `test_search_entries_per_tool_limit`)
- [x] `Retry-After` header present and parseable as integer ≥1 (`math.ceil` floor)
- [x] Limit resets after the window (`test_window_reset_via_monkeypatched_clock`)
- [x] No impact on normal sessions (defaults are well above typical usage; existing 69 tests still pass)
- [x] Limits configurable via env vars, documented in `.env.example`
- [x] Per-user isolation (`test_users_are_isolated`)
- [x] Public paths and unauthenticated requests unaffected (`test_public_paths_not_rate_limited`, `test_unauthenticated_returns_401_not_429`)
- [x] No new runtime dependencies (pure stdlib)

## Test plan

- [ ] CI green on the PR
- [ ] Manual smoke against a Railway preview: send `tools/call name=search_entries` 11 times in 60s with a real bearer token; confirm 11th returns `HTTP 429` with `Retry-After`, then succeeds after the window
- [ ] Confirm `MCP_RATE_LIMIT_DISABLED=true` fully bypasses the limiter (incident-response kill-switch)
- [ ] Confirm a malformed `MCP_RATE_LIMIT_PER_TOOL` value (e.g. `foo:bar`) fails loud at first request, not silently