### PR TITLE
Add Button component and complete .btn class system

### DIFF
--- a/web/frontend/src/__tests__/button-css-contract.test.ts
+++ b/web/frontend/src/__tests__/button-css-contract.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const css = readFileSync(resolve(__dirname, '../index.css'), 'utf8')
+
+describe('button CSS contract (issue #23)', () => {
+  it('defines a .btn base rule that includes white-space: nowrap', () => {
+    const baseMatch = css.match(/\.btn\s*\{([^}]*)\}/)
+    expect(baseMatch).not.toBeNull()
+    expect(baseMatch![1]).toContain('white-space: nowrap')
+  })
+
+  it.each([
+    'btn-primary',
+    'btn-secondary',
+    'btn-ghost',
+    'btn-danger',
+    'btn-link',
+  ])('defines .%s rule', (cls) => {
+    expect(css).toMatch(new RegExp(`\\.${cls}\\s*\\{`))
+  })
+
+  it.each(['btn-sm', 'btn-md', 'btn-lg'])('defines .%s rule', (cls) => {
+    expect(css).toMatch(new RegExp(`\\.${cls}\\s*\\{`))
+  })
+
+  it('defines .btn:focus-visible with outline declaration', () => {
+    const match = css.match(/\.btn:focus-visible\s*\{([^}]*)\}/)
+    expect(match).not.toBeNull()
+    expect(match![1]).toMatch(/outline\s*:/)
+  })
+
+  it('defines .btn:disabled rule', () => {
+    expect(css).toMatch(/\.btn:disabled\s*\{/)
+  })
+
+  it('contains a @media (prefers-reduced-motion: reduce) block', () => {
+    expect(css).toMatch(/@media\s*\(\s*prefers-reduced-motion:\s*reduce\s*\)/)
+  })
+})

--- a/web/frontend/src/components/Button.tsx
+++ b/web/frontend/src/components/Button.tsx
@@ -1,0 +1,27 @@
+type Variant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'link'
+type Size = 'sm' | 'md' | 'lg'
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant
+  size?: Size
+  ref?: React.Ref<HTMLButtonElement>
+}
+
+export function Button({
+  variant = 'primary',
+  size,
+  className,
+  type = 'button',
+  ref,
+  ...rest
+}: ButtonProps) {
+  const classes = [
+    'btn',
+    `btn-${variant}`,
+    size && `btn-${size}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+  return <button ref={ref} type={type} className={classes} {...rest} />
+}

--- a/web/frontend/src/components/CrisisDisclaimerModal.tsx
+++ b/web/frontend/src/components/CrisisDisclaimerModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { api, type UserSettings } from '../api/client'
+import { Button } from './Button'
 
 export function CrisisDisclaimerModal() {
   const [settings, setSettings] = useState<UserSettings | null>(null)
@@ -115,16 +116,16 @@ export function CrisisDisclaimerModal() {
           </p>
         )}
 
-        <button
-          type="button"
-          className="btn btn-primary btn-lg"
+        <Button
+          variant="primary"
+          size="lg"
           autoFocus
           disabled={submitting}
           onClick={() => void acknowledge()}
           style={{ width: '100%', justifyContent: 'center' }}
         >
           {submitting ? 'Saving…' : 'I understand'}
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/web/frontend/src/components/__tests__/Button.test.tsx
+++ b/web/frontend/src/components/__tests__/Button.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useRef, useEffect } from 'react'
+import { Button } from '../Button'
+
+describe('Button', () => {
+  it('renders a <button> with class "btn btn-primary" by default', () => {
+    render(<Button>Click me</Button>)
+    const btn = screen.getByRole('button', { name: /click me/i })
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn).toHaveClass('btn', 'btn-primary')
+  })
+
+  it('variant="ghost" produces btn-ghost and not btn-primary', () => {
+    render(<Button variant="ghost">Ghost</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveClass('btn', 'btn-ghost')
+    expect(btn).not.toHaveClass('btn-primary')
+  })
+
+  it('size="lg" produces btn-lg; without size no size class is emitted', () => {
+    const { rerender } = render(<Button size="lg">Large</Button>)
+    expect(screen.getByRole('button')).toHaveClass('btn-lg')
+
+    rerender(<Button>Default</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).not.toHaveClass('btn-sm')
+    expect(btn).not.toHaveClass('btn-md')
+    expect(btn).not.toHaveClass('btn-lg')
+  })
+
+  it('appends custom className without dropping base classes', () => {
+    render(<Button className="extra">Click</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveClass('btn', 'btn-primary', 'extra')
+  })
+
+  it('forwards ref to the underlying HTMLButtonElement', () => {
+    function Wrapper() {
+      const ref = useRef<HTMLButtonElement>(null)
+      useEffect(() => {
+        if (ref.current) {
+          ref.current.dataset.refOk = ref.current.tagName
+        }
+      })
+      return <Button ref={ref}>Ref</Button>
+    }
+    render(<Wrapper />)
+    const btn = screen.getByRole('button')
+    expect(btn.dataset.refOk).toBe('BUTTON')
+  })
+
+  it('fires onClick when clicked', () => {
+    const onClick = vi.fn()
+    render(<Button onClick={onClick}>Click</Button>)
+    fireEvent.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders disabled attribute and suppresses click', () => {
+    const onClick = vi.fn()
+    render(
+      <Button disabled onClick={onClick}>
+        Click
+      </Button>,
+    )
+    const btn = screen.getByRole('button')
+    expect(btn).toBeDisabled()
+    fireEvent.click(btn)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('defaults type to "button"; passing type="submit" overrides', () => {
+    const { rerender } = render(<Button>Default</Button>)
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+
+    rerender(<Button type="submit">Submit</Button>)
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit')
+  })
+})

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -453,17 +453,27 @@ button { font-family: inherit; }
 .toggle.on .toggle-thumb { left: 19px; }
 .toggle-label { font-size: 13.5px; color: var(--ink); }
 
-.btn { font-family: var(--font-body); font-weight: 500; border-radius: var(--r-sm); border: 1px solid transparent; cursor: pointer; transition: all 120ms var(--ease-out); display: inline-flex; align-items: center; gap: 8px; font-size: 14px; padding: 9px 16px; }
+.btn { font-family: var(--font-body); font-weight: 500; border-radius: var(--r-sm); border: 1px solid transparent; cursor: pointer; transition: all 120ms var(--ease-out); display: inline-flex; align-items: center; gap: 8px; font-size: 14px; padding: 9px 16px; white-space: nowrap; }
 .btn:active { transform: scale(0.98); }
+.btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.btn:disabled { cursor: not-allowed; opacity: 0.5; }
 .btn-primary { background: var(--terracotta); color: var(--paper); }
-.btn-primary:hover { background: var(--terracotta-2); }
+.btn-primary:hover { background: var(--terracotta-2); box-shadow: var(--shadow-sm); }
 .btn-secondary { background: transparent; color: var(--ink); border-color: var(--border-strong); }
 .btn-secondary:hover { background: var(--paper-2); }
+.btn-ghost { background: transparent; color: var(--ink); }
+.btn-ghost:hover { background: var(--paper-2); }
 .btn-danger { background: transparent; color: var(--rust); border-color: var(--rust); }
 .btn-danger:hover { background: var(--rust); color: var(--paper); }
+.btn-link { background: transparent; color: var(--slate); text-decoration: underline; text-underline-offset: 3px; border-color: transparent; padding: 0; }
+.btn-link:hover { color: var(--terracotta); }
 .btn-md { font-size: 15px; padding: 10px 18px; }
 .btn-sm { font-size: 13px; padding: 6px 12px; }
 .btn-lg { font-size: 16px; padding: 13px 22px; }
+@media (prefers-reduced-motion: reduce) {
+  .btn { transition: none; }
+  .btn:active { transform: none; }
+}
 
 /* responsive */
 @media (max-width: 800px) {

--- a/web/frontend/src/pages/Login.tsx
+++ b/web/frontend/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { Navigate } from 'react-router'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../store/auth'
 import { KindredMark } from '../components/Brand'
+import { Button } from '../components/Button'
 
 export function Login() {
   const session = useAuth((s) => s.session)
@@ -79,14 +80,14 @@ export function Login() {
           A reflective journaling companion.
         </p>
 
-        <button
-          type="button"
-          className="btn btn-primary btn-lg"
+        <Button
+          variant="primary"
+          size="lg"
           onClick={signIn}
           style={{ width: '100%', justifyContent: 'center' }}
         >
           Sign in with Google
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/web/frontend/src/pages/Settings.tsx
+++ b/web/frontend/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { api, type UserSettings } from '../api/client'
+import { Button } from '../components/Button'
 
 const ALL_TIMEZONES: string[] = Intl.supportedValuesOf('timeZone')
 
@@ -302,13 +303,12 @@ export function Settings() {
           </p>
         </div>
         <div className="set-control">
-          <button
-            type="button"
-            className="btn btn-secondary"
+          <Button
+            variant="secondary"
             onClick={() => void exportData()}
           >
             <DownloadIcon /> Export as JSON
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -320,13 +320,12 @@ export function Settings() {
           </p>
         </div>
         <div className="set-control">
-          <button
-            type="button"
-            className="btn btn-danger"
+          <Button
+            variant="danger"
             onClick={() => void deleteAccount()}
           >
             <TrashIcon /> Delete everything
-          </button>
+          </Button>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary

Completes the partial `.btn` class system in `web/frontend/src/index.css` and adds a thin React 19 `<Button>` wrapper at `web/frontend/src/components/Button.tsx`. Migrates three low-risk callers (CrisisDisclaimerModal, Login, Settings) to the new component.

This also fixes a latent visible bug on the landing page: `.btn-link` and `.btn-ghost` were referenced by `Landing.tsx` but undefined in CSS, so those buttons rendered as the unstyled `.btn` base. They now render with the new variant styling.

Fixes #23.

## Changes

### CSS (`web/frontend/src/index.css`)

- Add `white-space: nowrap` to base `.btn`.
- Add primary `:hover` shadow (`box-shadow: var(--shadow-sm)`).
- Define new `.btn-ghost` and `.btn-link` variants + their `:hover` states.
- Add `.btn:focus-visible` (2px `--accent` outline, 2px offset) for WCAG 2.2 SC 1.4.11.
- Add `.btn:disabled` (cursor: not-allowed, opacity: 0.5).
- Add `@media (prefers-reduced-motion: reduce)` block disabling the transition and press-scale.

### Component (`web/frontend/src/components/Button.tsx` — NEW)

- React 19-native (no `forwardRef`; `ref` is a regular prop).
- Typed `variant` (5 options) and `size` (3 options + omittable for the default app size).
- Defaults: `variant=\"primary\"`, `type=\"button\"` (avoids accidental form submission).
- Spreads native button attributes; merges caller-supplied `className`.
- No third-party deps (no `cva`).

### Migrations

- `web/frontend/src/components/CrisisDisclaimerModal.tsx` — acknowledgement button.
- `web/frontend/src/pages/Login.tsx` — Sign-in-with-Google button.
- `web/frontend/src/pages/Settings.tsx` — Export JSON + Delete-everything buttons.

### Tests

- `web/frontend/src/components/__tests__/Button.test.tsx` (NEW, 8 cases) — default render, variant/size mapping, className merge, ref forwarding, onClick, disabled, type default + override.
- `web/frontend/src/__tests__/button-css-contract.test.ts` (NEW, 12 cases) — file-introspection asserting all required `.btn-*` classes, `:focus-visible`, `:disabled`, and the `prefers-reduced-motion` block exist in `index.css`.

**Net diff**: 7 files, +177 / -18.

## Out of scope (deliberate)

- `Landing.tsx`, `Connect.tsx` tab bar, `Layout.tsx` sign-out glyph — see `NOT BUILDING` in plan; tab/icon buttons aren't `.btn`-shaped, and Landing has dark-background overrides best handled separately.
- No `cva` dependency, no polymorphic `as` prop, no loading state, no Storybook.

## Validation evidence

| Check | Command | Result |
|-------|---------|--------|
| Type check | `npm run typecheck` | PASS — `tsc --noEmit` clean |
| Lint | `npm run lint` | PASS — 0 errors, 0 warnings |
| Tests | `npm test -- --run` | PASS — 44/44 (was 24; +8 Button + 12 CSS contract) |
| Build | `npm run build` | PASS — `tsc -b && vite build` succeeded |
| Manual smoke | `npm run dev` + browser | SKIPPED — agent environment has no browser available; CSS contract test + Button unit tests cover the regressions the smoke pass would guard against. **Reviewer please verify visually**: keyboard focus ring on `/login` & `/app/settings`, landing-page `How it works →` buttons now styled, and `prefers-reduced-motion` disables the press-scale. |

### Test breakdown

| Test file | Cases | Status |
|-----------|-------|--------|
| `src/__tests__/button-css-contract.test.ts` | 12 | PASS (new) |
| `src/__tests__/design-tokens.test.ts` | 9 | PASS |
| `src/components/__tests__/Button.test.tsx` | 8 | PASS (new) |
| `src/components/__tests__/CrisisDisclaimerModal.test.tsx` | 3 | PASS (still green after migration) |
| `src/components/__tests__/Layout.test.tsx` | 5 | PASS |
| `src/pages/__tests__/Connect.test.tsx` | 5 | PASS |
| `src/pages/__tests__/Home.test.tsx` | 1 | PASS |
| `src/pages/__tests__/Privacy.test.tsx` | 1 | PASS |

## Test plan

- [ ] Reviewer pulls branch and runs `cd web/frontend && npm test -- --run && npm run typecheck && npm run lint && npm run build`.
- [ ] Visual smoke at `/` — confirm both `How it works →` CTAs (above-fold and endcap) render with the new link/ghost styling, not as bare `.btn` boxes.
- [ ] Visual smoke at `/login` — Sign-in-with-Google still looks like the primary CTA.
- [ ] Visual smoke at `/app/settings` — Export JSON + Delete everything unchanged in appearance; Delete still triggers the destructive flow.
- [ ] Tab through any page — focus ring is the periwinkle `--accent` color, 2px offset.
- [ ] DevTools → Rendering → Emulate `prefers-reduced-motion: reduce` → click any `.btn` → no scale-press animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)