### PR TITLE
Fix: automate Supabase migrations on merge to main

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,25 @@
+name: Migrate
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+
+      - name: Link Supabase project
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: supabase link --project-ref goxtnasdisqkfrldtbej --password ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Apply migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: supabase db push --linked --password ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ See [docs/setup.md](docs/setup.md) for client-specific setup (Claude Projects, C
 ```bash
 ./scripts/gates.sh   # run lint + typecheck + test across all three trees
 ```
+
+## GitHub Actions secrets
+
+Two secrets must be added in the repo's **Settings → Secrets and variables → Actions** for the migration workflow to run on every push to `main`:
+
+| Secret | Description |
+|---|---|
+| `SUPABASE_ACCESS_TOKEN` | Supabase personal access token (create at https://supabase.com/dashboard/account/tokens) |
+| `SUPABASE_DB_PASSWORD` | Production database password for your Supabase project |


### PR DESCRIPTION
## Summary

`POST /connect/token` returns 403 in prod with `new row violates row-level security policy for table "connector_tokens"`. Root cause: migration `002_service_role_audit.sql` — which adds the required `connector_tokens owner insert` RLS policy — has been on `main` since commit `80cf172` (PR #44/#52) but has never been applied to the prod database. The README documents `supabase db push` as a **manual** developer step and no CI workflow runs it, so prod schema drifted behind `main`.

This PR adds the missing automation so migration 002 ships on merge to `main` (resolving the outage) and so future migrations cannot drift the same way.

## Changes

- **NEW** `.github/workflows/migrate.yml` (+25): GitHub Actions workflow that runs `supabase db push` on every push to `main` and on `workflow_dispatch`. Uses the official `supabase/setup-cli@v1` action and the production project ref `goxtnasdisqkfrldtbej`.
- **UPDATE** `README.md` (+9): new "GitHub Actions secrets" section documenting the two required secrets (`SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`).

No application code, migration SQL, or test changes — the application code is correct; the bug is operational.

## Why this approach

- `push: branches: [main]` is the trigger that will apply migration 002 to prod and resolve the outage on merge.
- `workflow_dispatch` provides a manual re-run path from the Actions tab if a run fails partway (e.g. before secrets are configured).
- Independent from `ci.yml` so a flaky migrate doesn't block PR CI.
- `supabase db push` is idempotent — already-applied migrations are skipped, so safe to re-run and safe even if migration 002 has already been applied manually.
- Project ref `goxtnasdisqkfrldtbej` is the actual prod ref (per local follow-up commit `1114bb0`); the placeholder `kindred` from `supabase/config.toml` would fail to link.

## Supersedes #69

Open draft PR #69 (`feat/migration-ci`) attempts the same fix but uses the wrong `--project-ref` (`kindred` — the local CLI project name, not the prod ref). Recommend closing #69 once this lands.

## ⚠️ Required before merging

The repo's **Settings → Secrets and variables → Actions** must have both secrets configured, or the Migrate job will fail on first run and prod stays broken:

| Secret | Description |
|---|---|
| `SUPABASE_ACCESS_TOKEN` | Supabase personal access token |
| `SUPABASE_DB_PASSWORD` | Production database password |

## Validation

All gates pass locally (`./scripts/gates.sh` equivalents — see `validation.md`):

| Check | Result |
|---|---|
| mcp lint (ruff) | ✅ |
| mcp typecheck (mypy) | ✅ no issues, 12 source files |
| mcp tests (pytest) | ✅ 108 passed |
| web/backend lint (ruff) | ✅ |
| web/backend typecheck (mypy) | ✅ no issues, 11 source files |
| web/backend tests (pytest) | ✅ 18 passed |
| web/frontend lint (eslint) | ✅ 0 errors |
| web/frontend typecheck (tsc) | ✅ no errors |
| web/frontend tests (vitest) | ✅ 44 passed (8 files) |
| service-role boundary check (#44) | ✅ no service_role refs in request handlers |

The Migrate workflow itself can't be exercised on a PR (it's gated to `push: main` + `workflow_dispatch`); GitHub validates the YAML server-side on push.

## Test plan

- [ ] Confirm CI (`ci.yml`) is green on this PR. The Migrate job should NOT run on the PR (intentional).
- [ ] Confirm `SUPABASE_ACCESS_TOKEN` and `SUPABASE_DB_PASSWORD` are set in Actions secrets.
- [ ] Verify the project ref `goxtnasdisqkfrldtbej` matches the prod project in the Supabase dashboard.
- [ ] Merge to `main` and watch the **Migrate** job in the Actions tab. It should install the CLI, link the project, and run `supabase db push`.
- [ ] In the Supabase SQL editor:
  ```sql
  select policyname, cmd from pg_policies where tablename = 'connector_tokens';
  ```
  Expect both `connector_tokens owner select` and `connector_tokens owner insert`.
- [ ] Hit `POST /connect/token` from the Connect page (or curl with a real session) — expect 200 with a `kdr_…` token.
- [ ] Confirm Sentry stops receiving the `42501` events.
- [ ] Close PR #69 with a reference to this PR.

Fixes #67

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>