### PR TITLE
Fix: PKCE login loop — add /auth/callback route

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -155,7 +155,7 @@ site_url = "https://kindred.interstellarai.net"
 # The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
 # external_url = ""
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://kindred.interstellarai.net", "https://kindred.interstellarai.net/mcp-auth", "https://kindred-mcp.interstellarai.net/oauth/callback", "http://localhost:5173", "http://localhost:3000"]
+additional_redirect_urls = ["https://kindred.interstellarai.net", "https://kindred.interstellarai.net/auth/callback", "https://kindred.interstellarai.net/mcp-auth", "https://kindred-mcp.interstellarai.net/oauth/callback", "http://localhost:5173", "http://localhost:5173/auth/callback", "http://localhost:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to auth.external_url.

--- a/web/frontend/src/components/Layout.tsx
+++ b/web/frontend/src/components/Layout.tsx
@@ -92,6 +92,7 @@ function buildGitHubIssueUrl(pagePath: string): string {
 
 export function Layout() {
   const session = useAuth((s) => s.session)
+  const initialized = useAuth((s) => s.initialized)
   const location = useLocation()
   const navigate = useNavigate()
   const reportIssueUrl = useMemo(
@@ -99,6 +100,12 @@ export function Layout() {
     [location.pathname],
   )
 
+  // Don't navigate before auth has hydrated — otherwise we'd strip
+  // any in-flight ?code=… (PKCE) or hash fragments and bounce a
+  // legitimately signed-in user back to /login.
+  if (!initialized) {
+    return null
+  }
   if (!session) {
     return <Navigate to="/login" replace />
   }

--- a/web/frontend/src/components/__tests__/Layout.test.tsx
+++ b/web/frontend/src/components/__tests__/Layout.test.tsx
@@ -1,12 +1,16 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, Routes, Route } from 'react-router'
+
+const authState: { session: unknown; initialized: boolean } = {
+  session: { user: { email: 'tester@example.com' } },
+  initialized: true,
+}
 
 vi.mock('../../store/auth', () => ({
-  useAuth: (selector: (s: { session: unknown }) => unknown) =>
-    selector({
-      session: { user: { email: 'tester@example.com' } },
-    }),
+  useAuth: (
+    selector: (s: { session: unknown; initialized: boolean }) => unknown,
+  ) => selector(authState),
 }))
 
 vi.mock('../../lib/supabase', () => ({
@@ -119,5 +123,42 @@ describe('Layout — Report an issue link', () => {
     expect(body).not.toContain('q=secret')
     expect(body).not.toContain('#frag')
     expect(body).toContain('- **Page:** /app/search')
+  })
+})
+
+describe('Layout — auth gate', () => {
+  function renderGate() {
+    return render(
+      <MemoryRouter initialEntries={['/app']}>
+        <Routes>
+          <Route path="/app" element={<Layout />} />
+          <Route path="/login" element={<div>LOGIN_ROUTE</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+  }
+
+  it('renders nothing while auth is still initializing (does not <Navigate>)', () => {
+    authState.session = null
+    authState.initialized = false
+    try {
+      renderGate()
+      expect(screen.queryByText('LOGIN_ROUTE')).not.toBeInTheDocument()
+    } finally {
+      authState.session = { user: { email: 'tester@example.com' } }
+      authState.initialized = true
+    }
+  })
+
+  it('navigates to /login once initialized=true and session=null', () => {
+    authState.session = null
+    authState.initialized = true
+    try {
+      renderGate()
+      expect(screen.getByText('LOGIN_ROUTE')).toBeInTheDocument()
+    } finally {
+      authState.session = { user: { email: 'tester@example.com' } }
+      authState.initialized = true
+    }
   })
 })

--- a/web/frontend/src/lib/supabase.ts
+++ b/web/frontend/src/lib/supabase.ts
@@ -5,13 +5,24 @@ const url = import.meta.env.VITE_SUPABASE_URL ?? ''
 const anon = import.meta.env.VITE_SUPABASE_ANON_KEY ?? ''
 
 export const supabase = createClient(url, anon, {
-  auth: { flowType: 'pkce' },
+  auth: {
+    flowType: 'pkce',
+    // AuthCallback page calls exchangeCodeForSession() explicitly. If
+    // detectSessionInUrl were left on (the default), Supabase would race
+    // our explicit call and one of them would fail with "code already
+    // used" because PKCE codes are single-use.
+    detectSessionInUrl: false,
+  },
 })
 
 supabase.auth.onAuthStateChange((_event, session) => {
-  useAuth.getState().setSession(session)
+  const { setSession, setInitialized } = useAuth.getState()
+  setSession(session)
+  setInitialized(true)
 })
 
 void supabase.auth.getSession().then(({ data }) => {
-  useAuth.getState().setSession(data.session)
+  const { setSession, setInitialized } = useAuth.getState()
+  setSession(data.session)
+  setInitialized(true)
 })

--- a/web/frontend/src/main.tsx
+++ b/web/frontend/src/main.tsx
@@ -26,6 +26,7 @@ import { Settings } from './pages/Settings'
 import { Connect } from './pages/Connect'
 import { McpAuth } from './pages/McpAuth'
 import { Privacy } from './pages/Privacy'
+import { AuthCallback } from './pages/AuthCallback'
 
 const router = createBrowserRouter([
   {
@@ -35,6 +36,7 @@ const router = createBrowserRouter([
       // Public routes
       { path: '/', element: <Landing /> },
       { path: '/login', element: <Login /> },
+      { path: '/auth/callback', element: <AuthCallback /> },
       { path: '/mcp-auth', element: <McpAuth /> },
       { path: '/privacy', element: <Privacy /> },
       // Authenticated app routes

--- a/web/frontend/src/pages/AuthCallback.tsx
+++ b/web/frontend/src/pages/AuthCallback.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react'
+import { Navigate } from 'react-router'
+import { supabase } from '../lib/supabase'
+
+type Status = 'exchanging' | 'success' | 'error'
+
+export function AuthCallback() {
+  const [status, setStatus] = useState<Status>('exchanging')
+  const [errorMsg, setErrorMsg] = useState('')
+  const ran = useRef(false)
+
+  useEffect(() => {
+    // React StrictMode runs effects twice in dev — and PKCE codes are
+    // single-use, so the second exchange would fail. Mirror McpAuth.tsx.
+    if (ran.current) return
+    ran.current = true
+
+    const params = new URLSearchParams(window.location.search)
+    const code = params.get('code')
+    const errParam = params.get('error_description') ?? params.get('error')
+
+    if (errParam) {
+      setStatus('error')
+      setErrorMsg(errParam)
+      return
+    }
+    if (!code) {
+      setStatus('error')
+      setErrorMsg('Missing authorization code.')
+      return
+    }
+
+    void supabase.auth.exchangeCodeForSession(code).then(({ error }) => {
+      if (error) {
+        setStatus('error')
+        setErrorMsg(error.message)
+      } else {
+        setStatus('success')
+      }
+    })
+  }, [])
+
+  if (status === 'success') return <Navigate to="/app" replace />
+  if (status === 'error') {
+    const qs = new URLSearchParams({ error: errorMsg }).toString()
+    return <Navigate to={`/login?${qs}`} replace />
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--paper)',
+        color: 'var(--ink-3)',
+        fontFamily: 'var(--font-mono)',
+        fontSize: 12,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+      }}
+    >
+      Signing in…
+    </div>
+  )
+}

--- a/web/frontend/src/pages/Login.tsx
+++ b/web/frontend/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router'
+import { Navigate, useSearchParams } from 'react-router'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../store/auth'
 import { KindredMark } from '../components/Brand'
@@ -6,12 +6,14 @@ import { Button } from '../components/Button'
 
 export function Login() {
   const session = useAuth((s) => s.session)
+  const [searchParams] = useSearchParams()
+  const errorMsg = searchParams.get('error')
   if (session) return <Navigate to="/app" replace />
 
   const signIn = () => {
     void supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: { redirectTo: window.location.origin + '/app' },
+      options: { redirectTo: window.location.origin + '/auth/callback' },
     })
   }
 
@@ -79,6 +81,19 @@ export function Login() {
         >
           A reflective journaling companion.
         </p>
+
+        {errorMsg && (
+          <p
+            style={{
+              color: 'var(--rust)',
+              fontSize: 'var(--fs-sm)',
+              marginBottom: 'var(--sp-4)',
+            }}
+            role="alert"
+          >
+            {errorMsg}
+          </p>
+        )}
 
         <Button
           variant="primary"

--- a/web/frontend/src/pages/__tests__/AuthCallback.test.tsx
+++ b/web/frontend/src/pages/__tests__/AuthCallback.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router'
+
+const { exchangeCodeForSession } = vi.hoisted(() => ({
+  exchangeCodeForSession: vi.fn(),
+}))
+vi.mock('../../lib/supabase', () => ({
+  supabase: { auth: { exchangeCodeForSession } },
+}))
+
+import { AuthCallback } from '../AuthCallback'
+
+function renderAt(url: string) {
+  // window.location.search is what AuthCallback reads (not the router's
+  // location), so set it explicitly for each render.
+  const u = new URL(url, 'http://localhost')
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, search: u.search, pathname: u.pathname },
+    writable: true,
+    configurable: true,
+  })
+  return render(
+    <MemoryRouter initialEntries={[u.pathname + u.search]}>
+      <Routes>
+        <Route path="/auth/callback" element={<AuthCallback />} />
+        <Route path="/app" element={<div>APP</div>} />
+        <Route path="/login" element={<div>LOGIN</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('AuthCallback', () => {
+  beforeEach(() => exchangeCodeForSession.mockReset())
+
+  it('exchanges the PKCE code and navigates to /app on success', async () => {
+    exchangeCodeForSession.mockResolvedValue({ error: null })
+    renderAt('/auth/callback?code=abc123')
+    await waitFor(() => expect(screen.getByText('APP')).toBeInTheDocument())
+    expect(exchangeCodeForSession).toHaveBeenCalledWith('abc123')
+  })
+
+  it('redirects to /login when no code is present', async () => {
+    renderAt('/auth/callback')
+    await waitFor(() => expect(screen.getByText('LOGIN')).toBeInTheDocument())
+    expect(exchangeCodeForSession).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /login when the exchange fails', async () => {
+    exchangeCodeForSession.mockResolvedValue({
+      error: { message: 'bad code' },
+    })
+    renderAt('/auth/callback?code=abc123')
+    await waitFor(() => expect(screen.getByText('LOGIN')).toBeInTheDocument())
+  })
+
+  it('forwards an OAuth provider error from the URL to /login', async () => {
+    renderAt('/auth/callback?error=access_denied')
+    await waitFor(() => expect(screen.getByText('LOGIN')).toBeInTheDocument())
+    expect(exchangeCodeForSession).not.toHaveBeenCalled()
+  })
+})

--- a/web/frontend/src/store/auth.ts
+++ b/web/frontend/src/store/auth.ts
@@ -3,10 +3,14 @@ import type { Session } from '@supabase/supabase-js'
 
 type AuthState = {
   session: Session | null
+  initialized: boolean
   setSession: (s: Session | null) => void
+  setInitialized: (v: boolean) => void
 }
 
 export const useAuth = create<AuthState>((set) => ({
   session: null,
+  initialized: false,
   setSession: (session) => set({ session }),
+  setInitialized: (initialized) => set({ initialized }),
 }))


### PR DESCRIPTION
## Summary

Fixes the Google sign-in loop where users were bounced indefinitely between `/login` and Google's account picker. The PKCE `?code=` was being stripped from `/app?code=...` by `<Layout>`'s synchronous `<Navigate to=\"/login\" replace>` before Supabase could exchange it for a session.

The fix introduces a dedicated, unguarded `/auth/callback` page that owns the PKCE exchange, and adds an `initialized` flag to the auth store so guards can distinguish \"hydrating\" from \"signed out\".

Fixes #64

## Root Cause

1. `Login.tsx` redirected OAuth to `/app` (a guarded route).
2. `<Layout>` saw `session=null` synchronously on mount (the async `onAuthStateChange` hadn't fired yet) and called `<Navigate to=\"/login\" replace>`.
3. `replace` rewrote history without `?code=`, so Supabase's `exchangeCodeForSession()` had nothing to exchange.
4. The user landed back on `/login`, clicked Sign in again — repeat.

## Changes

| File | Action | Notes |
|------|--------|-------|
| `web/frontend/src/store/auth.ts` | UPDATE | Added `initialized: boolean` + `setInitialized` |
| `web/frontend/src/lib/supabase.ts` | UPDATE | Disabled `detectSessionInUrl` (callback page now owns the exchange — avoids \"code already used\" race); flips `initialized=true` after `getSession()` and on every `onAuthStateChange` |
| `web/frontend/src/pages/AuthCallback.tsx` | CREATE | New unguarded page; calls `exchangeCodeForSession`, navigates to `/app` on success or `/login?error=...` on failure. Uses `useRef` guard for StrictMode (PKCE codes are single-use) |
| `web/frontend/src/main.tsx` | UPDATE | Registered `/auth/callback` route alongside other public routes |
| `web/frontend/src/pages/Login.tsx` | UPDATE | `redirectTo` now points at `/auth/callback`; surfaces `?error=...` query param to the user |
| `web/frontend/src/components/Layout.tsx` | UPDATE | Renders `null` while `!initialized` instead of redirecting (defense in depth — also covers magic-link / refresh-token flows) |
| `supabase/config.toml` | UPDATE | Added `https://kindred.interstellarai.net/auth/callback` and `http://localhost:5173/auth/callback` to `additional_redirect_urls` |
| `web/frontend/src/pages/__tests__/AuthCallback.test.tsx` | CREATE | 4 tests: success → /app, missing code → /login, exchange failure → /login, OAuth provider error → /login |
| `web/frontend/src/components/__tests__/Layout.test.tsx` | UPDATE | Widened auth-store mock to include `initialized`; 2 new tests pin the gate behavior (`!initialized` does not navigate; `initialized && !session` does) |

## Validation

All checks ran in `web/frontend/` and passed on the first run — see `validation.md` in artifacts.

| Check | Command | Result |
|-------|---------|--------|
| Type check | `npm run typecheck` | ✅ no errors |
| Lint | `npm run lint` | ✅ 0 errors, 0 warnings |
| Tests | `npm test -- --run` | ✅ 70 / 70 (10 files, 1.78s) — includes 4 new AuthCallback tests + 2 new Layout gate tests, no regressions |
| Build | `npm run build` | ✅ compiled, 329 modules in 2.64s |

## Test Plan

- [ ] `cd web/frontend && bun run dev`, open `http://localhost:5173/login`, click \"Sign in with Google\", confirm landing on `/app` with no redirect loop
- [ ] Sign out, then visit `/app` directly in a fresh tab — confirm a brief blank screen (not a flash of `/login`) before redirect to `/login` (proves the `initialized` gate works)
- [ ] Visit `/auth/callback` directly with no `?code=` — confirm redirect to `/login?error=Missing+authorization+code.` and that the error message renders
- [ ] Confirm `supabase/config.toml` `additional_redirect_urls` contains both new entries

## ⚠️ Manual Follow-Up Required (out of repo)

`supabase/config.toml` only governs **local dev**. A maintainer with Dashboard access must add the same entries to **Supabase Dashboard → Authentication → URL Configuration → Redirect URLs**:

- `https://kindred.interstellarai.net/auth/callback`
- `http://localhost:5173/auth/callback`

Without the production entry, prod OAuth completes at Google but Supabase rejects the callback with `invalid_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)