### PR TITLE
Fix: skip Migrate when Supabase secrets absent

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -17,18 +17,23 @@ jobs:
       - name: Set up Supabase CLI
         uses: supabase/setup-cli@v1
 
-      - name: Verify required secrets
+      - name: Check required secrets
+        id: secrets
         run: |
           missing=()
           if [ -z "${SUPABASE_ACCESS_TOKEN//[[:space:]]/}" ]; then missing+=("SUPABASE_ACCESS_TOKEN"); fi
           if [ -z "${SUPABASE_DB_PASSWORD//[[:space:]]/}" ]; then missing+=("SUPABASE_DB_PASSWORD"); fi
           if [ ${#missing[@]} -gt 0 ]; then
-            echo "::error::Required secrets missing: ${missing[*]}. Add them in Settings → Secrets and variables → Actions (see README.md)."
-            exit 1
+            echo "::warning::Skipping migrations — required secrets not configured: ${missing[*]}. Add them in Settings → Secrets and variables → Actions (see README.md) to enable automatic migrations."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Link Supabase project
+        if: steps.secrets.outputs.skip != 'true'
         run: supabase link --project-ref goxtnasdisqkfrldtbej
 
       - name: Apply migrations
+        if: steps.secrets.outputs.skip != 'true'
         run: supabase db push --linked


### PR DESCRIPTION
## Summary

Converts the `Migrate` workflow's missing-secrets pre-flight check from a hard failure (`exit 1`) into a soft skip with a `::warning::` annotation. This stops main from going red on every push when `SUPABASE_ACCESS_TOKEN` / `SUPABASE_DB_PASSWORD` are not provisioned, while preserving fail-fast behavior when the secrets are present but invalid.

Fixes #75.

## Root Cause

PR #72 (commit `63b1074`) added a pre-flight that errors out when either Supabase secret is empty. The intent was to surface misconfiguration with a clear message instead of an obscure CLI failure. But the secrets have never been configured in this repo, so:

1. Every push to `main` failed the `Migrate` workflow at the pre-flight step.
2. `pipeline-health-cron.sh` files a fresh "Main CI red: migrate" issue per red push, producing a perpetual triage loop. Issue #75 was filed against `63b1074` itself — the hardening commit.

Hardening alone turned an obscure red into a loud red but did not reduce the red rate to zero, which is what the cron actually needs.

## Changes

`.github/workflows/migrate.yml` (+8 / -3):

- Renamed step `Verify required secrets` → `Check required secrets` and added `id: secrets`.
- Replaced `::error::` + `exit 1` with `::warning::` + `echo "skip=true" >> "$GITHUB_OUTPUT"`.
- Added `else` branch writing `skip=false` so the step output is always set.
- Gated `Link Supabase project` and `Apply migrations` on `if: steps.secrets.outputs.skip != 'true'`.

When secrets are missing, the job concludes `success` with two skipped steps and one `::warning::` annotation. When secrets are present, the gate evaluates `skip=false` and the migration runs as before. When secrets are present but invalid, `supabase link` / `supabase db push` fails naturally — preserving the fail-fast signal for real misconfiguration.

## Validation

| Check | Result |
|---|---|
| YAML parse (`python3 -c "import yaml; yaml.safe_load(...)"`) | Pass |
| Step renamed and `id: secrets` added | Pass |
| `::warning::` replaces `::error::`; no `exit 1` | Pass |
| Both `Link` and `Apply` steps gated on `steps.secrets.outputs.skip != 'true'` | Pass |
| Type check / lint / format / tests / build | n/a — only `.github/workflows/migrate.yml` changed; no JS/TS/Python touched; no `actionlint` configured in repo |

### Pending manual verification (post-merge)

1. Next `Migrate` run on `main` concludes `success` (was `failure`).
2. Run summary shows the `::warning::` annotation: "Skipping migrations — required secrets not configured: …".
3. `Link Supabase project` and `Apply migrations` show as **skipped** (grey).
4. `pipeline-health-cron.sh` does not file a fresh "Main CI red: migrate" issue.
5. Issue #75 auto-closes via `Fixes #75`.

## Scope Hygiene

Out of scope (intentionally untouched):

- Provisioning the Supabase secrets — repo-admin action in GitHub Settings, not code.
- `.github/workflows/ci.yml` — unrelated and green.
- `README.md:47-54` — already documents the secret requirement correctly.
- Job-level `env:` block (`migrate.yml:11-13`) — placement was deliberated in PR #72; kept as-is.
- Workflow trigger `push: branches: [main]` — kept; do not regress to manual-only (preserves auto-on-merge from PR #70).

## Test plan

- [ ] Merge to `main` and confirm the next `Migrate` run concludes `success` with the expected `::warning::` annotation and skipped sub-steps.
- [ ] Confirm `pipeline-health-cron.sh` does not auto-file a new "Main CI red" issue on the next push.
- [ ] Confirm issue #75 is auto-closed by the merged PR.
- [ ] (Optional) After a maintainer provisions the two secrets, confirm the next push runs `Link Supabase project` and `Apply migrations` rather than skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)