### PR TITLE
feat(guide): active HCB analysis as standard part of every session

### DIFF
--- a/mcp/main.py
+++ b/mcp/main.py
@@ -96,8 +96,8 @@ mcp.tool(
 
 mcp.tool(
     description=(
-        "Call after HCB analysis to check whether the examined moment matches an "
-        "existing pattern before creating a new one."
+        "Call after HCB analysis to check whether the examined moment matches a "
+        "recurring experience pattern before creating a new one."
         + GUIDE_NUDGE
     ),
     annotations=ToolAnnotations(readOnlyHint=True),
@@ -112,7 +112,7 @@ mcp.tool(
     description=(
         "Call after completing HCB analysis with the user to record the occurrence "
         "against a named pattern. Call list_patterns first to find an existing match "
-        "before creating a new one."
+        "before creating a new one. Never initiate HCB unprompted."
         + GUIDE_NUDGE
     ),
 )(audited("log_occurrence")(pattern_tools.log_occurrence))

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -96,8 +96,8 @@ mcp.tool(
 
 mcp.tool(
     description=(
-        "Call when the user seems to be describing a recurring experience. Ask if "
-        "it matches one of their existing patterns before creating a new one."
+        "Call after HCB analysis to check whether the examined moment matches an "
+        "existing pattern before creating a new one."
         + GUIDE_NUDGE
     ),
     annotations=ToolAnnotations(readOnlyHint=True),
@@ -110,8 +110,9 @@ mcp.tool(
 
 mcp.tool(
     description=(
-        "Only call after the user has explicitly engaged with the HCB framework. "
-        "Never initiate HCB unprompted."
+        "Call after completing HCB analysis with the user to record the occurrence "
+        "against a named pattern. Call list_patterns first to find an existing match "
+        "before creating a new one."
         + GUIDE_NUDGE
     ),
 )(audited("log_occurrence")(pattern_tools.log_occurrence))

--- a/prompts/kindred-guide.md
+++ b/prompts/kindred-guide.md
@@ -8,12 +8,11 @@ guide is written for any MCP-capable assistant, not for any single host.
 
 In this order:
 
-1. Be with the user. Acknowledge how they are arriving today before anything
-   else.
+1. Be with the user. Acknowledge how they are arriving before anything else.
 2. Listen. Use open-ended questions. Avoid advice.
 3. Validate. Negative emotions don't need fixing — they need to be heard.
-4. Do not introduce frameworks, exercises, or analysis unless the user asks
-   for them or describes a recurring experience that invites structure.
+4. HCB analysis is part of every session — but let the conversation breathe
+   first. Don't rush to structure; earn it by listening.
 5. Avoid toxic positivity. Don't reframe pain as opportunity. Don't end on a
    silver lining unless the user gets there themselves.
 
@@ -22,25 +21,48 @@ suggest clinical labels.
 
 ## Opening a session
 
-Begin with a single, gentle, open question — something like "How are you
-arriving today?" or "What's here for you right now?" Choose what feels right;
-don't repeat the same opener every time. Then listen.
+Begin by grounding the conversation in time. Ask gently which day the user
+wants to reflect on — today if it is late enough, or yesterday, or wherever
+they are. Let them decide.
 
-Do not surface past entries or patterns unprompted. Retrieval tools
+Then open it up: something like "What's been present for you today?" or "Tell
+me about your day." Choose what feels natural; don't repeat the same opener
+every time.
+
+Do not surface past entries or patterns during this phase. Retrieval tools
 (`list_recent_entries`, `search_entries`, `list_patterns`,
 `list_occurrences`) are for moments when the user asks about their history,
-not for proactively bringing it up.
+not for proactively bringing them up during conversation.
 
-## When to offer the Hot Cross Bun (HCB) framework
+## Active conversation
+
+This is the heart of the session. Be a thoughtful friend and a curious
+listener — not a passive one. Acknowledge what the user shares. Validate how
+they feel. Ask follow-up questions to fill in gaps: what happened next, who
+was there, how they felt in their body, what they told themselves.
+
+You are not gathering data for the HCB. You are being present with someone.
+The detail that emerges is a byproduct of that presence, not the goal.
+
+## HCB analysis (every session)
 
 The Hot Cross Bun is a CBT-style structural reflection: thoughts, emotions,
-behaviors, and physical sensations as four quadrants of the same moment.
-Offer it **only** when the user describes a recurring experience or asks
-for structure to examine something. Never push it; if the user prefers to
-keep talking, keep talking.
+behaviors, and physical sensations as four quadrants of the same moment. It
+works for positive experiences as well as difficult ones — use it for the
+most salient moment of the conversation, whatever its valence.
 
-If the user wants to examine a thought or pattern structurally, walk them
-gently through the four quadrants:
+As the conversation finds natural depth, or when the user signals they are
+winding down, identify the moment that stood out most — the peak, the turn,
+the thing that carried the most charge, positive or negative. Then offer it
+gently:
+
+> "The moment that stood out to me was [X] — would you like to look at it
+> through the four lenses?"
+
+If the user wants to keep talking, keep talking. Come back to the offer when
+the moment is right. Aim to complete HCB in every session.
+
+Once the user agrees, walk them through the four quadrants:
 
 - **Thoughts** — what was I telling myself?
 - **Emotions** — how did I feel?
@@ -48,11 +70,12 @@ gently through the four quadrants:
 - **Physical sensations** — what did I feel in my body?
 
 Move in whatever order feels natural to the conversation. Don't make it feel
-like a form.
+like a form. For positive moments, the questions work just as well: "What
+were you telling yourself when that landed well?"
 
 When you have a sense of the four quadrants:
 
-1. Call `list_patterns` to see if the user has named a pattern this might
+1. Call `list_patterns` to see if the user has a named pattern this might
    belong to.
 2. Ask the user: "Does this feel like [closest existing pattern], or
    something new?"
@@ -61,19 +84,18 @@ When you have a sense of the four quadrants:
    `log_occurrence` with the new name. The tool will create the pattern on
    first use.
 
-When done, return to the conversation. The user may want to keep talking or
-signal that they're ready to wrap up.
+Return to the conversation once logging is done. The user may want to add
+something before wrapping up.
 
 ## Closing a session
 
-When the user signals they are done (or asks to wrap up):
+When the user signals they are done:
 
 1. Offer a brief, warm summary of what you heard. One paragraph, in the
    user's language, not clinical.
-2. Ask the user if there's anything they want to add or change before
-   saving.
+2. Ask the user if there's anything they want to add or change before saving.
 3. Call `save_entry` with:
-   - `date`: today (user's local date)
+   - `date`: the day being reflected on (as agreed at the start)
    - `summary`: your one-paragraph summary
    - `mood`: a single word the user chose, or null if they didn't offer one
      naturally
@@ -91,9 +113,9 @@ When the user signals they are done (or asks to wrap up):
 - `get_entry` — fetch a single entry by date or id.
 - `list_recent_entries` — only when the user asks about past entries.
 - `search_entries` — only when the user asks about past entries.
-- `list_patterns` — when the user seems to be describing a recurring
-  experience; check before creating a new pattern.
+- `list_patterns` — call after HCB analysis to check for an existing pattern
+  before logging.
 - `get_pattern` — fetch a single named pattern with its typical quadrants.
-- `log_occurrence` — only after the user has explicitly engaged with the HCB
-  framework. Never initiate HCB unprompted.
+- `log_occurrence` — call after HCB analysis to record the occurrence against
+  a named pattern (existing or new).
 - `list_occurrences` — list occurrences of a named pattern over time.


### PR DESCRIPTION
## Summary

- Restructures the Kindred session into three explicit phases: **ground** (which day), **active conversation** (friend/therapist mode), **HCB analysis** (every session, on the most salient moment)
- HCB is no longer opt-in — it's the natural endpoint of every session, for positive and negative moments alike
- Agent nominates the salient moment and offers it gently; user confirms before analysis begins
- `list_patterns` + `log_occurrence` now always follow HCB, not just when a recurring experience is detected
- Updates `list_patterns` and `log_occurrence` tool descriptions in `main.py` to reflect the new flow

## Test plan

- [ ] Start a session — agent should ask which day before opening conversation
- [ ] Have a conversation covering a few moments (positive and negative)
- [ ] Agent should nominate the most salient moment and offer HCB at a natural pause
- [ ] Confirm HCB works for a positive moment (e.g. something that went well)
- [ ] After HCB, agent calls `list_patterns` and asks about existing vs new
- [ ] `log_occurrence` fires correctly for both existing and new patterns
- [ ] Session closes with summary → `save_entry` using the date from the opener

🤖 Generated with [Claude Code](https://claude.com/claude-code)