### PR TITLE
fix(mcp): surface real error messages to the agent

### DIFF
--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 from lib import db, embeddings
+from mcp.server.fastmcp.exceptions import ToolError
 
 from auth import current_user_id
 from tools import entries as entry_tools
@@ -67,9 +68,9 @@ async def test_save_entry_inserts_then_embeds(monkeypatch: pytest.MonkeyPatch) -
 
 async def test_get_entry_requires_exactly_one_arg(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(db, "get_entry_by_id", lambda u, j, i: {"id": i})
-    with pytest.raises(ValueError):
+    with pytest.raises(ToolError):
         await entry_tools.get_entry()
-    with pytest.raises(ValueError):
+    with pytest.raises(ToolError):
         await entry_tools.get_entry(date="2026-05-01", id=ENTRY_ID)
 
 
@@ -183,7 +184,7 @@ async def test_log_occurrence_creates_pattern_when_missing(
 
 
 async def test_log_occurrence_rejects_out_of_range_intensity() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ToolError):
         await pattern_tools.log_occurrence(
             pattern_name="x",
             entry_id=ENTRY_ID,

--- a/mcp/tools/entries.py
+++ b/mcp/tools/entries.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import Any
 
 from lib.services import entries as entries_service
+from mcp.server.fastmcp.exceptions import ToolError
 
 from auth import current_user_id
 
@@ -23,15 +24,18 @@ async def save_entry(
     per call — same-day callers will produce two rows.
     """
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        entries_service.save_entry,
-        user_id,
-        None,
-        date,
-        summary,
-        mood,
-        transcript,
-    )
+    try:
+        return await asyncio.to_thread(
+            entries_service.save_entry,
+            user_id,
+            None,
+            date,
+            summary,
+            mood,
+            transcript,
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def get_entry(
@@ -39,24 +43,33 @@ async def get_entry(
     id: str | None = None,
 ) -> dict[str, Any]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        entries_service.get_entry_by_date_or_id,
-        user_id,
-        None,
-        date=date,
-        entry_id=id,
-    )
+    try:
+        return await asyncio.to_thread(
+            entries_service.get_entry_by_date_or_id,
+            user_id,
+            None,
+            date=date,
+            entry_id=id,
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def list_recent_entries(limit: int = 10) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        entries_service.list_recent_entries, user_id, None, limit
-    )
+    try:
+        return await asyncio.to_thread(
+            entries_service.list_recent_entries, user_id, None, limit
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def search_entries(query: str, limit: int = 5) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        entries_service.search_entries, user_id, None, query, limit
-    )
+    try:
+        return await asyncio.to_thread(
+            entries_service.search_entries, user_id, None, query, limit
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc

--- a/mcp/tools/patterns.py
+++ b/mcp/tools/patterns.py
@@ -6,22 +6,29 @@ import asyncio
 from typing import Any
 
 from lib.services import patterns as patterns_service
+from mcp.server.fastmcp.exceptions import ToolError
 
 from auth import current_user_id
 
 
 async def list_patterns(active_since: str | None = None) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        patterns_service.list_patterns, user_id, None, active_since
-    )
+    try:
+        return await asyncio.to_thread(
+            patterns_service.list_patterns, user_id, None, active_since
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def get_pattern(name_or_id: str) -> dict[str, Any]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        patterns_service.get_pattern, user_id, None, name_or_id
-    )
+    try:
+        return await asyncio.to_thread(
+            patterns_service.get_pattern, user_id, None, name_or_id
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def log_occurrence(
@@ -36,30 +43,36 @@ async def log_occurrence(
     notes: str | None = None,
 ) -> str:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        patterns_service.log_occurrence,
-        user_id,
-        None,
-        pattern_name,
-        entry_id,
-        thoughts,
-        emotions,
-        behaviors,
-        sensations,
-        intensity,
-        trigger,
-        notes,
-    )
+    try:
+        return await asyncio.to_thread(
+            patterns_service.log_occurrence,
+            user_id,
+            None,
+            pattern_name,
+            entry_id,
+            thoughts,
+            emotions,
+            behaviors,
+            sensations,
+            intensity,
+            trigger,
+            notes,
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def list_occurrences(
     pattern_name_or_id: str, since: str | None = None
 ) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        patterns_service.list_occurrences,
-        user_id,
-        None,
-        pattern_name_or_id,
-        since,
-    )
+    try:
+        return await asyncio.to_thread(
+            patterns_service.list_occurrences,
+            user_id,
+            None,
+            pattern_name_or_id,
+            since,
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc


### PR DESCRIPTION
## Summary

- Wraps all MCP tool functions in `try/except → ToolError` so FastMCP returns the actual error message with `isError: true` instead of the generic `"Error occurred during tool execution"`
- Covers all failure modes: DB errors (APIError from supabase-py), validation (intensity range, missing args), not-found (entry, pattern)
- Agents can now read the error and retry with corrected arguments
- Updates tests: `ValueError` expectations → `ToolError` for the two validation tests

## Fixes

- **Bug 1 (save_entry + transcript)**: the real DB/serialization error will now surface — expected to reveal the root cause for a follow-up fix
- **Bug 2 (log_occurrence)**: same — real error (likely a DB constraint or JWT issue on insert_occurrence) will surface

## Test plan

- [ ] CI passes with updated test expectations
- [ ] Call `log_occurrence` with `intensity=7` — agent should see `"intensity must be between 1 and 5"` not a generic error
- [ ] Call `get_entry` with no args — agent should see `"provide exactly one of \`date\` or \`id\`"`
- [ ] Reproduce Bug 1 (save_entry with transcript) — agent should now see the actual DB error

🤖 Generated with [Claude Code](https://claude.com/claude-code)