### PR TITLE
Style: Login, Connect, McpAuth pages adopt design system

### DIFF
--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -598,6 +598,7 @@ section.hero { font-family: var(--font-body); font-size: var(--fs-md); letter-sp
 .step h3 em { font-style: italic; color: var(--terracotta); }
 .step p { margin: 0; color: var(--ink-2); font-size: 15px; line-height: 1.6; }
 .step-cmd { margin-top: var(--sp-4); font-family: var(--font-mono); font-size: 12px; color: var(--slate); background: var(--paper-2); padding: 6px 10px; border-radius: var(--r-xs); display: inline-block; border: 1px solid var(--border); }
+.steps.steps-stack { grid-template-columns: 1fr; gap: var(--sp-4); }
 
 /* ============================================================
    Conversation — the centerpiece

--- a/web/frontend/src/pages/Connect.tsx
+++ b/web/frontend/src/pages/Connect.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { api, type ConnectorToken } from '../api/client'
+import { Button } from '../components/Button'
 
 type ClientKey = 'claude-desktop' | 'cursor' | 'windsurf'
 
@@ -119,285 +120,271 @@ export function Connect() {
 
   const client = CLIENTS.find((c) => c.key === activeClient) ?? CLIENTS[0]
 
+  const cmdRowStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: 8,
+    alignItems: 'center',
+    marginTop: 'var(--sp-4)',
+    flexWrap: 'wrap',
+  }
+  const cmdCodeStyle: React.CSSProperties = {
+    flex: 1,
+    minWidth: 0,
+    marginTop: 0,
+    padding: '12px 14px',
+    fontSize: 13,
+    color: 'var(--ink)',
+    wordBreak: 'break-all',
+  }
+
   return (
     <>
       <div className="page-head">
         <div className="page-eye">
-          <span className="glyph">◈</span> Connector
+          <span className="glyph">◈</span> Account
         </div>
         <h1 className="page-title">
-          Connect Kindred to <em>your AI assistant</em>.
+          Connect to <em>Claude</em>
         </h1>
         <p className="page-sub">
-          Two minutes. Paste these into your AI assistant&apos;s connector settings. Once connected,
-          the three slash commands light up.
+          Two minutes to wire Kindred into Claude (or Cursor / Windsurf — pick a tab below). Once
+          connected, the three slash commands light up.
         </p>
       </div>
 
-      <div
-        style={{
-          background: 'var(--bg-elevated)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--r-lg)',
-          padding: 'var(--sp-5)',
-          marginBottom: 'var(--sp-5)',
-        }}
+      <ol
+        className="steps steps-stack"
+        style={{ listStyle: 'none', paddingLeft: 0, margin: 0 }}
       >
-        {/* Step 1 */}
-        <div className="entry-section-eye">Step 1 · MCP server URL</div>
-        <div
-          style={{
-            display: 'flex',
-            gap: 8,
-            alignItems: 'center',
-            marginBottom: 'var(--sp-4)',
-          }}
-        >
-          <code
-            style={{
-              flex: 1,
-              padding: '12px 14px',
-              background: 'var(--paper-2)',
-              border: '1px solid var(--border)',
-              borderRadius: 'var(--r-md)',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 13,
-              color: 'var(--ink)',
-              wordBreak: 'break-all',
-            }}
-          >
-            {MCP_URL}
-          </code>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={() => void copy(MCP_URL)}
-          >
-            Copy
-          </button>
-        </div>
+        {/* Step 1 — MCP URL */}
+        <li className="step">
+          <div className="step-num">
+            <span>Step 01</span>
+            <span className="glyph">✶</span>
+          </div>
+          <h3>
+            Add the <em>MCP URL</em>
+          </h3>
+          <p>This is the server your AI assistant will talk to.</p>
+          <div style={cmdRowStyle}>
+            <code className="step-cmd" style={cmdCodeStyle}>
+              {MCP_URL}
+            </code>
+            <Button variant="secondary" onClick={() => void copy(MCP_URL)}>
+              Copy
+            </Button>
+          </div>
+        </li>
 
-        {/* Step 2 */}
-        <div className="entry-section-eye">Step 2 · Connector token</div>
-        <div
-          role="note"
-          style={{
-            background: 'var(--paper-2)',
-            border: '1px solid var(--rust-2, var(--rust))',
-            borderLeftWidth: 3,
-            borderRadius: 'var(--r-md)',
-            padding: '10px 14px',
-            marginBottom: 'var(--sp-3)',
-            fontSize: 13,
-            color: 'var(--ink-2)',
-            lineHeight: 1.5,
-          }}
-        >
-          <strong>Treat this token like a password.</strong> Anyone who has it
-          can read your journal. Don&apos;t paste it into chat, screenshots, or
-          shared docs.
-        </div>
-        <div
-          style={{
-            display: 'flex',
-            gap: 8,
-            alignItems: 'center',
-            marginBottom: token?.expires_at ? 4 : 'var(--sp-4)',
-          }}
-        >
-          <code
-            style={{
-              flex: 1,
-              padding: '12px 14px',
-              background: 'var(--paper-2)',
-              border: '1px solid var(--border)',
-              borderRadius: 'var(--r-md)',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 13,
-              color: token ? 'var(--ink)' : 'var(--ink-3)',
-              wordBreak: 'break-all',
-            }}
-          >
-            {token ? token.token : 'kdr_••••••••••••••••••••••••'}
-          </code>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={() => void mint()}
-          >
-            {token ? 'Rotate' : 'Mint token'}
-          </button>
-          {token && (
-            <button
-              type="button"
-              className="btn btn-secondary"
-              onClick={() => void copy(token.token)}
-            >
-              {copied ? 'Copied' : 'Copy'}
-            </button>
-          )}
-        </div>
-
-        {token?.expires_at && (
-          <p
-            style={{
-              fontSize: 12,
-              color: 'var(--ink-3)',
-              margin: '0 0 var(--sp-4)',
-            }}
-          >
-            Expires {new Date(token.expires_at).toLocaleDateString()}
-          </p>
-        )}
-
-        {error && (
-          <p style={{ color: 'var(--rust)', fontSize: 13, margin: '0 0 var(--sp-3)' }}>
-            {error}
-          </p>
-        )}
-
-        {/* Step 3 — per-client tabs */}
-        <div className="entry-section-eye">Step 3 · Set up your AI</div>
-
-        <div
-          role="tablist"
-          aria-label="AI client"
-          style={{
-            display: 'flex',
-            gap: 0,
-            borderBottom: '1px solid var(--border)',
-            marginBottom: 'var(--sp-4)',
-            flexWrap: 'wrap',
-          }}
-        >
-          {CLIENTS.map((c) => {
-            const isActive = c.key === activeClient
-            return (
-              <button
-                key={c.key}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                onClick={() => setActiveClient(c.key)}
-                style={{
-                  background: isActive ? 'var(--bg-elevated)' : 'transparent',
-                  border: 'none',
-                  borderBottom: isActive
-                    ? '2px solid var(--terracotta)'
-                    : '2px solid transparent',
-                  marginBottom: -1,
-                  padding: '10px 16px',
-                  fontFamily: 'var(--font-sans)',
-                  fontSize: 14,
-                  color: isActive ? 'var(--ink)' : 'var(--ink-3)',
-                  cursor: 'pointer',
-                  fontWeight: isActive ? 500 : 400,
-                }}
-              >
-                {c.label}
-              </button>
-            )
-          })}
-        </div>
-
-        <div role="tabpanel" aria-label={`${client.label} setup`}>
-          <div className="entry-section-eye">Step 1 · Add the MCP server</div>
-          <p
-            style={{
-              color: 'var(--ink-2)',
-              fontSize: 14,
-              lineHeight: 1.55,
-              margin: '8px 0 var(--sp-4)',
-              maxWidth: '64ch',
-            }}
-          >
-            {client.addServer}
-          </p>
-
-          <div className="entry-section-eye">Step 2 · Custom instruction</div>
-          <p
-            style={{
-              color: 'var(--ink-2)',
-              fontSize: 14,
-              lineHeight: 1.55,
-              margin: '8px 0 var(--sp-3)',
-              maxWidth: '64ch',
-            }}
-          >
-            {client.oneLinerHint}
-          </p>
+        {/* Step 2 — Connector token */}
+        <li className="step">
+          <div className="step-num">
+            <span>Step 02</span>
+            <span className="glyph">✶</span>
+          </div>
+          <h3>
+            Mint a <em>connector token</em>
+          </h3>
+          <p>Mint once, paste into your AI assistant&apos;s connector settings.</p>
           <div
+            role="note"
             style={{
-              display: 'flex',
-              gap: 8,
-              alignItems: 'center',
-              marginBottom: 'var(--sp-4)',
+              background: 'var(--paper-2)',
+              border: '1px solid var(--rust-2, var(--rust))',
+              borderLeftWidth: 3,
+              borderRadius: 'var(--r-md)',
+              padding: '10px 14px',
+              marginTop: 'var(--sp-3)',
+              fontSize: 13,
+              color: 'var(--ink-2)',
+              lineHeight: 1.5,
             }}
           >
+            <strong>Treat this token like a password.</strong> Anyone who has it can read your
+            journal. Don&apos;t paste it into chat, screenshots, or shared docs.
+          </div>
+          <div style={cmdRowStyle}>
             <code
+              className="step-cmd"
               style={{
-                flex: 1,
-                padding: '12px 14px',
-                background: 'var(--paper-2)',
-                border: '1px solid var(--border)',
-                borderRadius: 'var(--r-md)',
-                fontFamily: 'var(--font-mono)',
-                fontSize: 13,
-                color: 'var(--ink)',
-                wordBreak: 'break-word',
+                ...cmdCodeStyle,
+                color: token ? 'var(--ink)' : 'var(--ink-3)',
               }}
             >
-              {ONE_LINER}
+              {token ? token.token : 'kdr_••••••••••••••••••••••••'}
             </code>
-            <button
-              type="button"
-              className="btn btn-secondary"
-              onClick={() => void copy(ONE_LINER)}
+            <Button variant="secondary" onClick={() => void mint()}>
+              {token ? 'Rotate' : 'Mint token'}
+            </Button>
+            {token && (
+              <Button variant="secondary" onClick={() => void copy(token.token)}>
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+            )}
+          </div>
+          {token?.expires_at && (
+            <p
+              style={{
+                fontSize: 12,
+                color: 'var(--ink-3)',
+                margin: 'var(--sp-2) 0 0',
+              }}
             >
-              Copy
-            </button>
+              Expires {new Date(token.expires_at).toLocaleDateString()}
+            </p>
+          )}
+          {error && (
+            <p
+              style={{
+                color: 'var(--rust)',
+                fontSize: 13,
+                margin: 'var(--sp-3) 0 0',
+              }}
+            >
+              {error}
+            </p>
+          )}
+        </li>
+
+        {/* Step 3 — Set up your AI assistant */}
+        <li className="step">
+          <div className="step-num">
+            <span>Step 03</span>
+            <span className="glyph">✶</span>
+          </div>
+          <h3>
+            Set up your <em>AI assistant</em>
+          </h3>
+          <p>Pick your client below — the per-step instructions will adjust.</p>
+
+          <div
+            role="tablist"
+            aria-label="AI client"
+            style={{
+              display: 'flex',
+              gap: 0,
+              borderBottom: '1px solid var(--border)',
+              marginTop: 'var(--sp-4)',
+              marginBottom: 'var(--sp-4)',
+              flexWrap: 'wrap',
+            }}
+          >
+            {CLIENTS.map((c) => {
+              const isActive = c.key === activeClient
+              return (
+                <button
+                  key={c.key}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setActiveClient(c.key)}
+                  style={{
+                    background: isActive ? 'var(--bg-elevated)' : 'transparent',
+                    border: 'none',
+                    borderBottom: isActive
+                      ? '2px solid var(--terracotta)'
+                      : '2px solid transparent',
+                    marginBottom: -1,
+                    padding: '10px 16px',
+                    fontFamily: 'var(--font-sans)',
+                    fontSize: 14,
+                    color: isActive ? 'var(--ink)' : 'var(--ink-3)',
+                    cursor: 'pointer',
+                    fontWeight: isActive ? 500 : 400,
+                  }}
+                >
+                  {c.label}
+                </button>
+              )
+            })}
           </div>
 
-          <div className="entry-section-eye">Step 3 · Test it</div>
-          <p
-            style={{
-              color: 'var(--ink-2)',
-              fontSize: 14,
-              lineHeight: 1.55,
-              margin: '8px 0 var(--sp-4)',
-              maxWidth: '64ch',
-            }}
-          >
-            {client.testHint}
-          </p>
+          <div role="tabpanel" aria-label={`${client.label} setup`}>
+            <div className="entry-section-eye">Step 1 · Add the MCP server</div>
+            <p
+              style={{
+                color: 'var(--ink-2)',
+                fontSize: 14,
+                lineHeight: 1.55,
+                margin: '8px 0 var(--sp-4)',
+                maxWidth: '64ch',
+              }}
+            >
+              {client.addServer}
+            </p>
 
-          <div className="entry-section-eye">Step 4 · Troubleshooting</div>
-          <ul
-            style={{
-              color: 'var(--ink-2)',
-              fontSize: 14,
-              lineHeight: 1.55,
-              margin: '8px 0 0',
-              paddingLeft: 20,
-              maxWidth: '64ch',
-            }}
-          >
-            {client.troubleshooting.map((t) => (
-              <li key={t.issue} style={{ marginBottom: 6 }}>
-                <strong>{t.issue}</strong> — {t.fix}
-              </li>
-            ))}
-          </ul>
-          <a
-            href={client.docsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'var(--terracotta)', fontSize: 14, display: 'inline-block', marginTop: 'var(--sp-3)' }}
-          >
-            Official docs →
-          </a>
-        </div>
-      </div>
+            <div className="entry-section-eye">Step 2 · Custom instruction</div>
+            <p
+              style={{
+                color: 'var(--ink-2)',
+                fontSize: 14,
+                lineHeight: 1.55,
+                margin: '8px 0 var(--sp-3)',
+                maxWidth: '64ch',
+              }}
+            >
+              {client.oneLinerHint}
+            </p>
+            <div style={{ ...cmdRowStyle, marginTop: 0 }}>
+              <code
+                className="step-cmd"
+                style={{ ...cmdCodeStyle, wordBreak: 'break-word' }}
+              >
+                {ONE_LINER}
+              </code>
+              <Button variant="secondary" onClick={() => void copy(ONE_LINER)}>
+                Copy
+              </Button>
+            </div>
+
+            <div className="entry-section-eye" style={{ marginTop: 'var(--sp-4)' }}>
+              Step 3 · Test it
+            </div>
+            <p
+              style={{
+                color: 'var(--ink-2)',
+                fontSize: 14,
+                lineHeight: 1.55,
+                margin: '8px 0 var(--sp-4)',
+                maxWidth: '64ch',
+              }}
+            >
+              {client.testHint}
+            </p>
+
+            <div className="entry-section-eye">Step 4 · Troubleshooting</div>
+            <ul
+              style={{
+                color: 'var(--ink-2)',
+                fontSize: 14,
+                lineHeight: 1.55,
+                margin: '8px 0 0',
+                paddingLeft: 20,
+                maxWidth: '64ch',
+              }}
+            >
+              {client.troubleshooting.map((t) => (
+                <li key={t.issue} style={{ marginBottom: 6 }}>
+                  <strong>{t.issue}</strong> — {t.fix}
+                </li>
+              ))}
+            </ul>
+            <a
+              href={client.docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: 'var(--terracotta)',
+                fontSize: 14,
+                display: 'inline-block',
+                marginTop: 'var(--sp-3)',
+              }}
+            >
+              Official docs →
+            </a>
+          </div>
+        </li>
+      </ol>
     </>
   )
 }

--- a/web/frontend/src/pages/Login.tsx
+++ b/web/frontend/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { Navigate, useSearchParams } from 'react-router'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../store/auth'
-import { KindredMark } from '../components/Brand'
+import { KindredWordmark } from '../components/Brand'
 import { Button } from '../components/Button'
 
 export function Login() {
@@ -42,24 +42,11 @@ export function Login() {
         <div
           style={{
             display: 'flex',
-            alignItems: 'center',
             justifyContent: 'center',
-            gap: 10,
             marginBottom: 'var(--sp-6)',
           }}
         >
-          <KindredMark size={36} />
-          <span
-            style={{
-              fontFamily: 'var(--font-display)',
-              fontSize: 28,
-              lineHeight: 1,
-              letterSpacing: '-0.01em',
-            }}
-          >
-            <em>Kindred</em>
-            <span style={{ color: 'var(--terracotta)' }}>.</span>
-          </span>
+          <KindredWordmark markSize={36} />
         </div>
 
         <h1
@@ -74,12 +61,15 @@ export function Login() {
         </h1>
         <p
           style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
             color: 'var(--ink-3)',
-            fontSize: 'var(--fs-sm)',
+            letterSpacing: '0.04em',
             marginBottom: 'var(--sp-6)',
+            lineHeight: 1.5,
           }}
         >
-          A reflective journaling companion.
+          Your entries are encrypted. We store nothing we don&apos;t need.
         </p>
 
         {errorMsg && (

--- a/web/frontend/src/pages/McpAuth.tsx
+++ b/web/frontend/src/pages/McpAuth.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { supabase } from '../lib/supabase'
 import { KindredWordmark } from '../components/Brand'
+import { Button } from '../components/Button'
 
 const MCP_BASE = import.meta.env.VITE_MCP_BASE_URL ?? 'https://kindred-mcp.interstellarai.net'
 
@@ -51,7 +52,9 @@ export function McpAuth() {
         const { redirect_url } = (await resp.json()) as { redirect_url: string }
         sessionStorage.removeItem('mcp_flow_id')
         setStatus('done')
-        window.location.href = redirect_url
+        setTimeout(() => {
+          window.location.href = redirect_url
+        }, 600)
       } catch (err) {
         setStatus('error')
         setErrorMsg(String(err))
@@ -121,6 +124,56 @@ export function McpAuth() {
           <p style={{ color: 'var(--ink-3)', fontSize: 'var(--fs-sm)', margin: 0 }}>
             {errorMsg}
           </p>
+          <div style={{ marginTop: 'var(--sp-5)' }}>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                window.location.href = '/app/connect'
+              }}
+            >
+              Try again
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (status === 'done') {
+    return (
+      <div style={wrapStyle}>
+        <div style={cardStyle}>
+          {brandRow}
+          <div
+            style={{
+              color: 'var(--moss)',
+              fontSize: 36,
+              lineHeight: 1,
+              marginBottom: 'var(--sp-3)',
+            }}
+            aria-hidden="true"
+          >
+            ✓
+          </div>
+          <p
+            style={{
+              fontFamily: 'var(--font-display)',
+              fontSize: 'var(--fs-h3)',
+              fontWeight: 400,
+              margin: 0,
+            }}
+          >
+            Connected.
+          </p>
+          <p
+            style={{
+              color: 'var(--ink-3)',
+              fontSize: 'var(--fs-sm)',
+              margin: 'var(--sp-2) 0 0',
+            }}
+          >
+            Returning to your AI assistant…
+          </p>
         </div>
       </div>
     )
@@ -142,26 +195,15 @@ export function McpAuth() {
         >
           {status === 'completing' ? 'Completing authentication…' : 'Connecting…'}
         </p>
-        <div
-          style={{
-            display: 'inline-flex',
-            gap: 6,
-            alignItems: 'center',
-          }}
+        <span
+          className="typing"
+          style={{ justifyContent: 'center' }}
+          aria-hidden="true"
         >
-          {[0, 0.18, 0.36].map((delay, i) => (
-            <span
-              key={i}
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                background: 'var(--moss)',
-                animation: `bounce 1.4s ease-in-out ${delay}s infinite`,
-              }}
-            />
-          ))}
-        </div>
+          <span />
+          <span />
+          <span />
+        </span>
       </div>
     </div>
   )

--- a/web/frontend/src/pages/Search.tsx
+++ b/web/frontend/src/pages/Search.tsx
@@ -73,6 +73,14 @@ export function Search() {
         </p>
       </div>
 
+      <div className="readonly-banner">
+        <span className="lock">🔒</span>
+        <span>
+          <strong>Read-only.</strong> Entries are written through the journaling conversation in
+          your AI assistant — not from here.
+        </span>
+      </div>
+
       <div className="search-bar">
         <SearchIcon />
         <input

--- a/web/frontend/src/pages/__tests__/Connect.test.tsx
+++ b/web/frontend/src/pages/__tests__/Connect.test.tsx
@@ -79,7 +79,7 @@ describe('Connect', () => {
   it('renders the provider-neutral page heading', () => {
     renderConnect()
     expect(
-      screen.getByRole('heading', { name: /connect kindred to your ai assistant/i }),
+      screen.getByRole('heading', { name: /connect to claude/i }),
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

Restyle the three auth/onboarding entry-point pages (`Login.tsx`, `Connect.tsx`, `McpAuth.tsx`) so they use Kindred's established design-system primitives (tokens, `.btn`, `KindredWordmark`, `.page-head`, `.steps`/`.step`/`.step-cmd`, `.typing`, `.readonly-banner`) instead of inline styles, ad-hoc wordmarks, and custom keyframes. Markup-only restyle — no functional behavior (mint, copy, OAuth, tab switching) changes.

Fixes #31

## Changes

- **`web/frontend/src/pages/Login.tsx`** — Replace inline `<KindredMark>` + custom `<span>` wordmark with `<KindredWordmark markSize={36} />`; swap generic subtext for mono 11px ink-3 privacy line ("Your entries are encrypted. We store nothing we don't need."). +14/-23.
- **`web/frontend/src/pages/Connect.tsx`** — Page-head now reads `◈ Account` / `Connect to *Claude*` (matching sidebar label from #87). Body restructured into `<ol class="steps steps-stack">` with `.step` cards, `.step-cmd` for code blocks. All primary `<button class="btn">` actions converted to `<Button variant="…">`. Tab buttons (`role="tab"`) intentionally left inline — only callsite, bespoke active-tab indicator. +233/-249.
- **`web/frontend/src/pages/McpAuth.tsx`** — Inline 3-dot bounce keyframe replaced with global `.typing` class (which already has `prefers-reduced-motion` fallback). Adds explicit `'done'` visual state with moss ✓ "Connected." card visible ~600ms before redirect. Adds `<Button variant="secondary">Try again</Button>` linking to `/app/connect` on the error state. PKCE single-flight `ran.current` guard untouched. +50/-9.
- **`web/frontend/src/index.css`** — One-line addition: `.steps.steps-stack { grid-template-columns: 1fr; gap: var(--sp-4); }` so `.step` cards stack single-column without disturbing the landing 3-column layout. +1/-0.
- **`web/frontend/src/pages/Search.tsx`** — Adds the standard `<div class="readonly-banner">` (issue spec: "wherever appropriate"). +8/-0.
- **`web/frontend/src/pages/__tests__/Connect.test.tsx`** — Updates one assertion: heading regex `/connect kindred to your ai assistant/i` → `/connect to claude/i` to match new title. +1/-1.

Total: 6 files, +310/-282. No new components, no new tokens, no new dependencies.

## Deviations from plan

1. **`.typing` defensive centering** — Added `style={{ justifyContent: 'center' }}` on the `.typing` span as belt-and-suspenders even though parent `text-align: center` already centers it. No-op but protects against future text-align changes.
2. **Connect step body copy** — Plan left wording flexible; chose three short neutral sentences for the `<p>` bodies inside each `.step` (e.g. "This is the server your AI assistant will talk to.") to avoid dangling `<h3>`s.
3. **Tab-panel ONE_LINER row marginTop** — Used `marginTop: 0` instead of `var(--sp-4)` to avoid double-spacing inside the existing `entry-section-eye` rhythm.

## Validation

| Check | Result |
|-------|--------|
| `npm run typecheck` | ✅ Pass — no TS errors |
| `npm run lint` | ✅ Pass — no ESLint errors |
| `npm test -- --run` | ✅ 106/106 pass across 14 files |
| `npm run build` | ✅ Built in 3.27s |

Relevant suites all green: `Connect.test.tsx` (7/7, with updated heading regex), `button-css-contract` (12/12, no `.btn` regression), `landing-css-contract` (8/8, no `.steps`/`.step` regression), `design-tokens` (9/9), `Brand` (18/18). No regressions in `Home`, `Patterns`, `Privacy`, `Settings`, `Landing`, `Layout`, `AuthCallback`, `CrisisDisclaimerModal`, `Button` suites.

Vite build emits the pre-existing >500 kB chunk-size advisory; unrelated to this CSS/markup-only PR.

## Test plan

- [ ] Visit `/login` — verify wordmark and mono privacy subtext render.
- [ ] Sign in → click "Connect to Claude" in sidebar → verify page-head says `◈ Account` / `Connect to Claude`, body shows three numbered `.step` cards.
- [ ] Token mint → rotate → copy flow still works end-to-end.
- [ ] Switch tabs (Claude Desktop / Cursor / Windsurf) — `aria-selected` flips and panel content swaps.
- [ ] Trigger MCP OAuth flow — confirm moss ✓ "Connected." card flashes ~600ms before redirect.
- [ ] Force MCP error path — confirm "Try again" button appears and links to `/app/connect`.
- [ ] Visit `/search` — readonly-banner appears at the top.
- [ ] DevTools → enable `prefers-reduced-motion` → confirm typing indicator pulses (opacity) instead of bouncing.
- [ ] Resize to ≤800px — Connect cards stack, Login card centers, no horizontal overflow.