### PR TITLE
Style: Settings page adopts spec title and reusable Toggle (#30)

### DIFF
--- a/web/frontend/src/components/Toggle.tsx
+++ b/web/frontend/src/components/Toggle.tsx
@@ -1,0 +1,19 @@
+type ToggleProps = {
+  checked: boolean
+  onChange: (val: boolean) => void
+  label: string
+}
+
+export function Toggle({ checked, onChange, label }: ToggleProps) {
+  return (
+    <label
+      className={`toggle ${checked ? 'on' : ''}`}
+      onClick={() => onChange(!checked)}
+    >
+      <span className="toggle-track">
+        <span className="toggle-thumb" />
+      </span>
+      <span className="toggle-label">{label}</span>
+    </label>
+  )
+}

--- a/web/frontend/src/components/__tests__/Toggle.test.tsx
+++ b/web/frontend/src/components/__tests__/Toggle.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Toggle } from '../Toggle'
+
+describe('Toggle', () => {
+  it('renders with class "toggle" (no "on") when checked={false}', () => {
+    render(<Toggle checked={false} onChange={() => {}} label="Notify me" />)
+    const label = screen.getByText('Notify me').closest('label')
+    expect(label).toHaveClass('toggle')
+    expect(label).not.toHaveClass('on')
+  })
+
+  it('renders with class "toggle on" when checked={true}', () => {
+    render(<Toggle checked={true} onChange={() => {}} label="Notify me" />)
+    const label = screen.getByText('Notify me').closest('label')
+    expect(label).toHaveClass('toggle', 'on')
+  })
+
+  it('renders the label text inside .toggle-label', () => {
+    render(<Toggle checked={false} onChange={() => {}} label="Save transcripts" />)
+    const labelSpan = screen.getByText('Save transcripts')
+    expect(labelSpan).toHaveClass('toggle-label')
+  })
+
+  it('calls onChange(true) when clicked while unchecked', () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={false} onChange={onChange} label="Toggle me" />)
+    fireEvent.click(screen.getByText('Toggle me').closest('label')!)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('calls onChange(false) when clicked while checked', () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={true} onChange={onChange} label="Toggle me" />)
+    fireEvent.click(screen.getByText('Toggle me').closest('label')!)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/web/frontend/src/pages/Settings.tsx
+++ b/web/frontend/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import {
   type UserSettings,
 } from '../api/client'
 import { Button } from '../components/Button'
+import { Toggle } from '../components/Toggle'
 
 const ALL_TIMEZONES = Intl.supportedValuesOf('timeZone')
 
@@ -121,25 +122,6 @@ function TimezoneInput({
         </ul>
       )}
     </div>
-  )
-}
-
-function Toggle({
-  on,
-  onChange,
-  label,
-}: {
-  on: boolean
-  onChange: (val: boolean) => void
-  label: string
-}) {
-  return (
-    <label className={`toggle ${on ? 'on' : ''}`} onClick={() => onChange(!on)}>
-      <span className="toggle-track">
-        <span className="toggle-thumb" />
-      </span>
-      <span className="toggle-label">{label}</span>
-    </label>
   )
 }
 
@@ -297,7 +279,7 @@ export function Settings() {
           <span className="glyph">◈</span> Settings
         </div>
         <h1 className="page-title">
-          Your <em>data</em>, your terms.
+          <em>Settings</em>
         </h1>
         <p className="page-sub">A few small toggles. Nothing else hidden behind submenus.</p>
       </div>
@@ -335,7 +317,7 @@ export function Settings() {
         </div>
         <div className="set-control">
           <Toggle
-            on={settings.transcript_enabled}
+            checked={settings.transcript_enabled}
             onChange={(val) => void save({ transcript_enabled: val })}
             label={
               settings.transcript_enabled

--- a/web/frontend/src/pages/__tests__/Settings.test.tsx
+++ b/web/frontend/src/pages/__tests__/Settings.test.tsx
@@ -70,6 +70,14 @@ describe('Settings — connector tokens section', () => {
     expect(await screen.findByText(/no tokens yet/i)).toBeInTheDocument()
   })
 
+  it('renders the spec page title', async () => {
+    mockEndpoints([])
+    render(<Settings />)
+    expect(
+      await screen.findByRole('heading', { name: /^Settings$/i }),
+    ).toBeInTheDocument()
+  })
+
   it('renders an active token row with status, created date, and last used', async () => {
     mockEndpoints([ACTIVE_TOKEN])
     render(<Settings />)

--- a/web/frontend/src/pages/__tests__/Settings.test.tsx
+++ b/web/frontend/src/pages/__tests__/Settings.test.tsx
@@ -78,6 +78,25 @@ describe('Settings — connector tokens section', () => {
     ).toBeInTheDocument()
   })
 
+  it('toggling Save transcripts patches /settings with transcript_enabled', async () => {
+    mockEndpoints([])
+    apiPatch.mockResolvedValueOnce({
+      ...SETTINGS_RESPONSE,
+      transcript_enabled: false,
+    })
+
+    render(<Settings />)
+
+    const label = await screen.findByText(/On — summary \+ transcript/i)
+    fireEvent.click(label.closest('label')!)
+
+    await waitFor(() => {
+      expect(apiPatch).toHaveBeenCalledWith('/settings', {
+        transcript_enabled: false,
+      })
+    })
+  })
+
   it('renders an active token row with status, created date, and last used', async () => {
     mockEndpoints([ACTIVE_TOKEN])
     render(<Settings />)


### PR DESCRIPTION
## Summary

Aligns `web/frontend/src/pages/Settings.tsx` with issue #30: swaps the page-head `<h1>` to the spec wording `<em>Settings</em>`, and extracts the inline Toggle into a reusable `components/Toggle.tsx` with the spec's `{ checked, onChange, label }` prop API. Existing `.toggle*` and `.set-*` CSS in `web/frontend/src/index.css:438-454` is unchanged — no CSS work was required.

## Changes

| File | Action | Lines |
|------|--------|-------|
| `web/frontend/src/components/Toggle.tsx` | CREATE | +19 |
| `web/frontend/src/components/__tests__/Toggle.test.tsx` | CREATE | +41 |
| `web/frontend/src/pages/Settings.tsx` | UPDATE | +3 / -21 |
| `web/frontend/src/pages/__tests__/Settings.test.tsx` | UPDATE | +8 / -0 |

Total: 4 files, +70 / -21.

- Reusable `Toggle` mirrors the `Button.tsx` shape (single named export, props-as-type, controlled component, no internal state).
- `Settings.tsx` drops the inline `function Toggle({ on, ... })` (was 127-144), imports `Toggle` from `../components/Toggle`, and renames the call-site prop from `on` → `checked`.
- Page-title `<h1>` swapped from "Your *data*, your terms." to `<em>Settings</em>`, matching the convention set by #29 (Search) and #91 (Patterns).

## Out of Scope

- Hypothetical Account/Notifications/Data sections from the issue body — `UserSettings` does not yet expose `display_name`, and the existing surfaces (Timezone, Save transcripts, Connector tokens, Export, Delete account) are real features. Following the precedent of #29 and #91: apply primitives to the real product, don't rewrite content.
- New CSS — `.toggle*` and `.set-*` rules already ship.
- Page-sub copy and `TimezoneInput` — unchanged.

## Validation

| Check | Result |
|-------|--------|
| `npm run typecheck` | Pass (no errors) |
| `npm run lint` | Pass (0 errors, 0 warnings) |
| `npm test -- --run Toggle Settings` | Pass (2 files, 11 tests) |
| `npm test -- --run` (full suite) | Pass (16 files, 121 tests) |
| `npm run build` | Pass (tsc -b && vite build) |

`Settings.test.tsx` grew from 5 to 6 tests (added spec page-title heading match anchored to `/^Settings$/i`). `Toggle.test.tsx` adds 5 new tests covering off-class, on-class, label rendering, and click→onChange in both directions. No regressions in pre-existing connector-token tests.

## Test Plan

- [x] Type check, lint, full test suite, build all green
- [ ] Manual smoke: `npm run dev` → visit `/app/settings`, confirm title reads "*Settings*" and the "Save transcripts" toggle still toggles and persists

Fixes #30