### PR TITLE
Fix: surface MCP tool errors + pin Supabase CLI for migrations

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up Supabase CLI
         uses: supabase/setup-cli@v1
+        with:
+          version: 2.98.2
 
       - name: Check required secrets
         id: secrets

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 from lib import db, embeddings
+from mcp.server.fastmcp.exceptions import ToolError
 
 from auth import current_user_id
 from tools import entries as entry_tools
@@ -67,9 +68,9 @@ async def test_save_entry_inserts_then_embeds(monkeypatch: pytest.MonkeyPatch) -
 
 async def test_get_entry_requires_exactly_one_arg(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(db, "get_entry_by_id", lambda u, j, i: {"id": i})
-    with pytest.raises(ValueError):
+    with pytest.raises(ToolError):
         await entry_tools.get_entry()
-    with pytest.raises(ValueError):
+    with pytest.raises(ToolError):
         await entry_tools.get_entry(date="2026-05-01", id=ENTRY_ID)
 
 
@@ -183,7 +184,7 @@ async def test_log_occurrence_creates_pattern_when_missing(
 
 
 async def test_log_occurrence_rejects_out_of_range_intensity() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ToolError):
         await pattern_tools.log_occurrence(
             pattern_name="x",
             entry_id=ENTRY_ID,

--- a/mcp/tools/entries.py
+++ b/mcp/tools/entries.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import Any
 
 from lib.services import entries as entries_service
+from mcp.server.fastmcp.exceptions import ToolError
 
 from auth import current_user_id
 
@@ -23,15 +24,18 @@ async def save_entry(
     per call — same-day callers will produce two rows.
     """
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        entries_service.save_entry,
-        user_id,
-        None,
-        date,
-        summary,
-        mood,
-        transcript,
-    )
+    try:
+        return await asyncio.to_thread(
+            entries_service.save_entry,
+            user_id,
+            None,
+            date,
+            summary,
+            mood,
+            transcript,
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def get_entry(
@@ -39,24 +43,33 @@ async def get_entry(
     id: str | None = None,
 ) -> dict[str, Any]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        entries_service.get_entry_by_date_or_id,
-        user_id,
-        None,
-        date=date,
-        entry_id=id,
-    )
+    try:
+        return await asyncio.to_thread(
+            entries_service.get_entry_by_date_or_id,
+            user_id,
+            None,
+            date=date,
+            entry_id=id,
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def list_recent_entries(limit: int = 10) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        entries_service.list_recent_entries, user_id, None, limit
-    )
+    try:
+        return await asyncio.to_thread(
+            entries_service.list_recent_entries, user_id, None, limit
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def search_entries(query: str, limit: int = 5) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        entries_service.search_entries, user_id, None, query, limit
-    )
+    try:
+        return await asyncio.to_thread(
+            entries_service.search_entries, user_id, None, query, limit
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc

--- a/mcp/tools/patterns.py
+++ b/mcp/tools/patterns.py
@@ -6,22 +6,29 @@ import asyncio
 from typing import Any
 
 from lib.services import patterns as patterns_service
+from mcp.server.fastmcp.exceptions import ToolError
 
 from auth import current_user_id
 
 
 async def list_patterns(active_since: str | None = None) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        patterns_service.list_patterns, user_id, None, active_since
-    )
+    try:
+        return await asyncio.to_thread(
+            patterns_service.list_patterns, user_id, None, active_since
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def get_pattern(name_or_id: str) -> dict[str, Any]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        patterns_service.get_pattern, user_id, None, name_or_id
-    )
+    try:
+        return await asyncio.to_thread(
+            patterns_service.get_pattern, user_id, None, name_or_id
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def log_occurrence(
@@ -36,30 +43,36 @@ async def log_occurrence(
     notes: str | None = None,
 ) -> str:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        patterns_service.log_occurrence,
-        user_id,
-        None,
-        pattern_name,
-        entry_id,
-        thoughts,
-        emotions,
-        behaviors,
-        sensations,
-        intensity,
-        trigger,
-        notes,
-    )
+    try:
+        return await asyncio.to_thread(
+            patterns_service.log_occurrence,
+            user_id,
+            None,
+            pattern_name,
+            entry_id,
+            thoughts,
+            emotions,
+            behaviors,
+            sensations,
+            intensity,
+            trigger,
+            notes,
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def list_occurrences(
     pattern_name_or_id: str, since: str | None = None
 ) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
-    return await asyncio.to_thread(
-        patterns_service.list_occurrences,
-        user_id,
-        None,
-        pattern_name_or_id,
-        since,
-    )
+    try:
+        return await asyncio.to_thread(
+            patterns_service.list_occurrences,
+            user_id,
+            None,
+            pattern_name_or_id,
+            since,
+        )
+    except Exception as exc:
+        raise ToolError(str(exc)) from exc


### PR DESCRIPTION
## Summary

- Surfaces tool errors to the agent as structured error responses instead of swallowing them with a generic message
- Pins Supabase CLI to v2.98.2 in the migrate workflow — the unpinned version was too old to parse `config.toml`, causing every migration run to fail at the link step (and silently skip due to the existing secret-check guard)

## Why migrations were never running

`supabase/setup-cli@v1` was pulling an old CLI version that didn't recognise newer `config.toml` keys (`auth.oauth_server`, `db.migrations.enabled`, etc.), causing `supabase link` to exit 1. The missing-secrets guard was masking this because the workflow was already skipping on secret absence — once secrets were added today, the real failure surfaced.

## Test plan

- [ ] Merge and confirm migrate workflow runs to completion on main
- [ ] Verify `lookup_connector_token` function exists in prod DB (resolves the auth 404 that was blocking all MCP tool calls)
- [ ] Confirm `list_patterns` and other tools work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)