### PR TITLE
ci: pin Supabase CLI to v2.98.2 to fix migrations

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up Supabase CLI
         uses: supabase/setup-cli@v1
+        with:
+          version: 2.98.2
 
       - name: Check required secrets
         id: secrets


### PR DESCRIPTION
## Summary

- Pins Supabase CLI to v2.98.2 in the migrate workflow

The unpinned `setup-cli@v1` action was installing an old CLI version that couldn't parse newer `config.toml` keys (`auth.oauth_server`, `db.migrations.enabled`, etc.). Every migration run was failing at `supabase link` — once secrets were added today, this failure surfaced. `lookup_connector_token` was never deployed to prod, breaking all MCP auth.

## Test plan

- [ ] Migrate workflow runs to completion on merge
- [ ] `lookup_connector_token` function exists in prod DB
- [ ] `list_patterns` and other MCP tools work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)