### PR TITLE
feat: delete entry UI and API

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up Supabase CLI
         uses: supabase/setup-cli@v1
+        with:
+          version: 2.98.2
 
       - name: Check required secrets
         id: secrets

--- a/lib/db.py
+++ b/lib/db.py
@@ -150,6 +150,11 @@ def list_recent_entries(
     return list(res.data or [])
 
 
+def delete_entry(user_id: str, jwt_token: str | None, entry_id: str) -> None:
+    _table(user_id, jwt_token, "entry_embeddings").delete().eq("user_id", user_id).eq("entry_id", entry_id).execute()
+    _table(user_id, jwt_token, "entries").delete().eq("user_id", user_id).eq("id", entry_id).execute()
+
+
 # ---------------------------------------------------------------------------
 # embeddings + semantic search
 # ---------------------------------------------------------------------------
@@ -381,6 +386,7 @@ async def update_user_metadata(
 
 __all__ = [
     "anon_client",
+    "delete_entry",
     "find_pattern_by_name",
     "get_entry_by_date",
     "get_entry_by_id",

--- a/lib/db.py
+++ b/lib/db.py
@@ -151,8 +151,20 @@ def list_recent_entries(
 
 
 def delete_entry(user_id: str, jwt_token: str | None, entry_id: str) -> None:
-    _table(user_id, jwt_token, "entry_embeddings").delete().eq("user_id", user_id).eq("entry_id", entry_id).execute()
-    _table(user_id, jwt_token, "entries").delete().eq("user_id", user_id).eq("id", entry_id).execute()
+    (
+        _table(user_id, jwt_token, "entry_embeddings")
+        .delete()
+        .eq("user_id", user_id)
+        .eq("entry_id", entry_id)
+        .execute()
+    )
+    (
+        _table(user_id, jwt_token, "entries")
+        .delete()
+        .eq("user_id", user_id)
+        .eq("id", entry_id)
+        .execute()
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/lib/services/entries.py
+++ b/lib/services/entries.py
@@ -78,3 +78,9 @@ def search_entries(
         raise ValueError("query must not be empty")
     vector = embeddings.embed(query)
     return db.match_entries(user_id, jwt_token, vector, limit)
+
+
+def delete_entry(user_id: str, jwt_token: str | None, entry_id: str) -> None:
+    if db.get_entry_by_id(user_id, jwt_token, entry_id) is None:
+        raise LookupError("entry not found")
+    db.delete_entry(user_id, jwt_token, entry_id)

--- a/web/backend/routes/entries.py
+++ b/web/backend/routes/entries.py
@@ -1,4 +1,4 @@
-"""GET /entries, GET /entries/:id — read-only."""
+"""GET /entries, GET /entries/:id, DELETE /entries/:id."""
 
 from __future__ import annotations
 
@@ -31,6 +31,19 @@ def get_entry(
         return entries_service.get_entry_with_occurrences(
             user["user_id"], user["jwt"], entry_id
         )
+    except LookupError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="entry not found"
+        ) from None
+
+
+@router.delete("/{entry_id}", status_code=204)
+def delete_entry(
+    entry_id: str,
+    user: dict[str, Any] = Depends(get_current_user),
+) -> None:
+    try:
+        entries_service.delete_entry(user["user_id"], user["jwt"], entry_id)
     except LookupError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="entry not found"

--- a/web/frontend/src/pages/EntryDetail.tsx
+++ b/web/frontend/src/pages/EntryDetail.tsx
@@ -8,6 +8,22 @@ export function EntryDetail() {
   const [entry, setEntry] = useState<Entry | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [showTranscript, setShowTranscript] = useState(false)
+  const [deleteState, setDeleteState] = useState<'idle' | 'confirm' | 'deleting'>('idle')
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  async function handleDelete() {
+    if (deleteState === 'idle') { setDeleteState('confirm'); return }
+    if (deleteState === 'confirm') {
+      setDeleteState('deleting')
+      try {
+        await api.delete(`/entries/${id}`)
+        void navigate('/app')
+      } catch (e) {
+        setDeleteError((e as Error).message)
+        setDeleteState('idle')
+      }
+    }
+  }
 
   useEffect(() => {
     if (!id) return
@@ -43,6 +59,28 @@ export function EntryDetail() {
         <div className="entry-detail-meta">
           {entry.mood && <span className="mood-big">◉ {entry.mood}</span>}
           {entry.transcript ? 'transcript on' : 'summary only'}
+        </div>
+        <div className="entry-detail-delete">
+          <button
+            type="button"
+            className="btn btn-danger btn-sm"
+            onClick={() => void handleDelete()}
+            disabled={deleteState === 'deleting'}
+          >
+            {deleteState === 'idle' && 'Delete entry'}
+            {deleteState === 'confirm' && 'Yes, delete'}
+            {deleteState === 'deleting' && 'Deleting…'}
+          </button>
+          {deleteState === 'confirm' && (
+            <button
+              type="button"
+              className="btn btn-sm"
+              onClick={() => setDeleteState('idle')}
+            >
+              Cancel
+            </button>
+          )}
+          {deleteError && <span style={{ color: 'var(--rust)' }}>{deleteError}</span>}
         </div>
       </div>
 

--- a/web/frontend/src/pages/__tests__/EntryDetail.test.tsx
+++ b/web/frontend/src/pages/__tests__/EntryDetail.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router'
 
 vi.mock('../../api/client', () => ({
-  api: { get: vi.fn() },
+  api: { get: vi.fn(), delete: vi.fn() },
 }))
 
 import { EntryDetail } from '../EntryDetail'
@@ -128,5 +128,34 @@ describe('EntryDetail', () => {
     renderDetail()
     await waitFor(() => expect(document.querySelector('.back-link')).not.toBeNull())
     expect(screen.getByRole('button', { name: /all entries/i })).toBeInTheDocument()
+  })
+
+  it('clicking "Delete entry" once shows confirm state', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(sampleEntry)
+    renderDetail()
+    await waitFor(() => screen.getByRole('button', { name: 'Delete entry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }))
+    expect(screen.getByRole('button', { name: 'Yes, delete' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+  })
+
+  it('cancel returns to idle state', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(sampleEntry)
+    renderDetail()
+    await waitFor(() => screen.getByRole('button', { name: 'Delete entry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getByRole('button', { name: 'Delete entry' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull()
+  })
+
+  it('confirming calls api.delete and navigates to /app', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce(sampleEntry)
+    vi.mocked(api.delete).mockResolvedValueOnce(undefined)
+    renderDetail()
+    await waitFor(() => screen.getByRole('button', { name: 'Delete entry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, delete' }))
+    await waitFor(() => expect(vi.mocked(api.delete)).toHaveBeenCalledWith('/entries/e1'))
   })
 })


### PR DESCRIPTION
## Summary
- Adds `DELETE /entries/:id` backend route (204, cleans up `entry_embeddings` first then `entries`)
- Two-step confirmation delete button on `EntryDetail` — idle → confirm → deleting → navigate to `/app`
- 3 new frontend tests; all 171 pass

## Test plan
- [ ] Open an entry, click "Delete entry" — button changes to "Yes, delete" + Cancel appears
- [ ] Click Cancel — returns to idle state
- [ ] Click "Delete entry" → "Yes, delete" — entry deleted, redirected to home
- [ ] Deleted entry no longer appears in entries list

🤖 Generated with [Claude Code](https://claude.com/claude-code)