### PR TITLE
feat(mcp): require transcript and mood on save_entry

### DIFF
--- a/mcp/main.py
+++ b/mcp/main.py
@@ -65,8 +65,8 @@ GUIDE_NUDGE = " If you have not already, read the kindred://guide resource for u
 mcp.tool(
     description=(
         "Call at the end of a session. Always confirm the summary with the user "
-        "before saving. Ask for a single mood word only if the user has offered it "
-        "naturally."
+        "before saving. Ask the user for a single mood word and the full conversation "
+        "transcript before calling."
         + GUIDE_NUDGE
     ),
 )(audited("save_entry")(entry_tools.save_entry))

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -61,7 +61,12 @@ async def test_save_entry_inserts_then_embeds(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(embeddings, "embed", fake_embed)
     monkeypatch.setattr(db, "insert_embedding", fake_insert_embedding)
 
-    result = await entry_tools.save_entry("2026-05-01", "today was hard")
+    result = await entry_tools.save_entry(
+        "2026-05-01",
+        "today was hard",
+        "heavy",
+        [{"role": "user", "content": "today was hard"}],
+    )
     assert result == ENTRY_ID
     assert calls == ["insert_entry", "embed", "insert_embedding"]
 

--- a/mcp/tools/entries.py
+++ b/mcp/tools/entries.py
@@ -13,8 +13,8 @@ from tools import _call
 async def save_entry(
     date: str,
     summary: str,
-    mood: str | None = None,
-    transcript: list[dict[str, str]] | None = None,
+    mood: str,
+    transcript: list[dict[str, str]],
 ) -> str:
     """Persist a journaling session and embed its summary.
 


### PR DESCRIPTION
## Summary
- `transcript` and `mood` are now required parameters on the `save_entry` MCP tool
- FastMCP will expose them as required in the JSON schema, so MCP clients must always provide both before saving
- Updated tool description to instruct the AI to collect both fields before calling

## Test plan
- [ ] `mcp/tests/test_tools.py` passes (10/10 green locally)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)