### PR TITLE
Add calendar sidebar to entries list

### DIFF
--- a/web/frontend/src/components/EntryCalendar.tsx
+++ b/web/frontend/src/components/EntryCalendar.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react'
+import { type EntrySummary } from '../api/client'
+
+/** Returns a local-time ISO date string "YYYY-MM-DD" without UTC shift. */
+function toLocalISO(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+const DOW = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+
+interface Props {
+  entries: EntrySummary[]
+  selected: string | null
+  onSelect: (date: string | null) => void
+}
+
+export function EntryCalendar({ entries, selected, onSelect }: Props) {
+  const today = new Date()
+  const todayStr = toLocalISO(today)
+
+  const [view, setView] = useState<{ year: number; month: number }>(() => ({
+    year: today.getFullYear(),
+    month: today.getMonth(),
+  }))
+
+  // Set of dates that have entries, restricted to the viewed month
+  const entryDates = new Set(entries.map((e) => e.date))
+
+  // First day of month and how many days in month
+  const firstOfMonth = new Date(view.year, view.month, 1)
+  const daysInMonth = new Date(view.year, view.month + 1, 0).getDate()
+  const startDow = firstOfMonth.getDay() // 0 = Sunday
+
+  const monthName = firstOfMonth.toLocaleDateString('en-US', { month: 'long' })
+  const yearStr = String(view.year)
+
+  // Count entries in viewed month
+  const monthPrefix = `${view.year}-${String(view.month + 1).padStart(2, '0')}`
+  const countThisMonth = entries.filter((e) => e.date.startsWith(monthPrefix)).length
+
+  function prevMonth() {
+    setView(({ year, month }) => {
+      if (month === 0) return { year: year - 1, month: 11 }
+      return { year, month: month - 1 }
+    })
+  }
+
+  function nextMonth() {
+    setView(({ year, month }) => {
+      if (month === 11) return { year: year + 1, month: 0 }
+      return { year, month: month + 1 }
+    })
+  }
+
+  function goToday() {
+    setView({ year: today.getFullYear(), month: today.getMonth() })
+    onSelect(todayStr)
+  }
+
+  function handleDayClick(dateStr: string) {
+    if (selected === dateStr) {
+      onSelect(null)
+    } else {
+      onSelect(dateStr)
+    }
+  }
+
+  // Build cells: leading empty cells + day cells
+  const cells: Array<{ type: 'empty'; key: string } | { type: 'day'; day: number; dateStr: string }> = []
+
+  for (let i = 0; i < startDow; i++) {
+    cells.push({ type: 'empty', key: `empty-${i}` })
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateStr = `${monthPrefix}-${String(d).padStart(2, '0')}`
+    cells.push({ type: 'day', day: d, dateStr })
+  }
+
+  return (
+    <div className="cal">
+      <div className="cal-eye">
+        <span className="glyph">◈</span> Calendar
+      </div>
+
+      <div className="cal-head">
+        <div className="cal-title">
+          <span className="cal-month">{monthName}</span>
+          <span className="cal-year">{yearStr}</span>
+        </div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          <button className="cal-arrow" onClick={prevMonth} aria-label="Previous month">‹</button>
+          <button className="cal-arrow" onClick={nextMonth} aria-label="Next month">›</button>
+        </div>
+      </div>
+
+      <div className="cal-grid">
+        {DOW.map((dow) => (
+          <div key={dow} className="cal-dow">{dow}</div>
+        ))}
+        {cells.map((cell) => {
+          if (cell.type === 'empty') {
+            return <div key={cell.key} className="cal-cell is-empty" />
+          }
+          const { day, dateStr } = cell
+          const hasEntry = entryDates.has(dateStr)
+          const isToday = dateStr === todayStr
+          const isSelected = dateStr === selected
+
+          const classes = [
+            'cal-cell',
+            hasEntry ? 'has-entry' : '',
+            isToday ? 'is-today' : '',
+            isSelected ? 'is-selected' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')
+
+          return (
+            <button
+              key={dateStr}
+              className={classes}
+              onClick={() => handleDayClick(dateStr)}
+              aria-label={dateStr}
+              aria-pressed={isSelected}
+            >
+              <span className="cal-num">{day}</span>
+              {hasEntry && <span className="cal-mark" />}
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="cal-foot">
+        <div className="cal-legend">
+          <span className="lg">
+            <span className="sw" />
+            Entry
+          </span>
+          <span className="lg lg-today">
+            <span className="sw" />
+            Today
+          </span>
+        </div>
+        <div className="cal-foot-meta">
+          <span>{countThisMonth} this month</span>
+          <span>
+            <button className="cal-link" onClick={goToday}>Today</button>
+            {selected !== null && (
+              <button className="cal-link" onClick={() => onSelect(null)}>Clear</button>
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -482,6 +482,178 @@ button { font-family: inherit; }
   .btn:active { transform: none; }
 }
 
+/* ============================================================
+   Entries: layout with calendar rail
+   ============================================================ */
+.entries-layout {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: var(--sp-6);
+  align-items: start;
+}
+.entries-col { min-width: 0; }
+
+.cal {
+  position: sticky;
+  top: var(--sp-6);
+  background: var(--paper-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--sp-4);
+}
+.cal-eye {
+  font-family: var(--font-mono); font-size: 10px; color: var(--ink-3);
+  letter-spacing: 0.14em; text-transform: uppercase;
+  margin-bottom: var(--sp-3);
+}
+.cal-eye .glyph { color: var(--terracotta); margin-right: 6px; }
+.cal-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 8px; margin-bottom: var(--sp-3);
+}
+.cal-title { display: flex; align-items: baseline; gap: 6px; }
+.cal-month {
+  font-family: var(--font-display); font-style: italic; font-size: 22px;
+  color: var(--ink); letter-spacing: -0.01em; line-height: 1;
+}
+.cal-year {
+  font-family: var(--font-mono); font-size: 11px; color: var(--ink-3);
+  letter-spacing: 0.06em;
+}
+.cal-arrow {
+  background: transparent; border: 1px solid var(--border);
+  border-radius: var(--r-sm); width: 26px; height: 26px;
+  font-size: 16px; color: var(--ink-2); cursor: pointer;
+  display: grid; place-items: center; line-height: 1;
+  transition: all 120ms var(--ease-out);
+}
+.cal-arrow:hover { background: var(--bg-elevated); color: var(--terracotta); border-color: var(--terracotta-3); }
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+.cal-dow {
+  font-family: var(--font-mono); font-size: 9px; color: var(--ink-3);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  text-align: center; padding: 6px 0 4px;
+}
+.cal-cell {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  background: transparent; border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--ink-2);
+  cursor: pointer;
+  display: grid; place-items: center;
+  padding: 0;
+  transition: all 120ms var(--ease-out);
+}
+.cal-cell .cal-num { line-height: 1; }
+.cal-cell.is-empty { cursor: default; pointer-events: none; }
+.cal-cell:hover:not(.is-empty):not(.is-selected) {
+  background: var(--paper);
+  border-color: var(--border);
+  color: var(--ink);
+}
+.cal-cell.has-entry { color: var(--ink); font-weight: 500; }
+.cal-cell .cal-mark {
+  position: absolute; bottom: 4px; left: 50%; transform: translateX(-50%);
+  width: 4px; height: 4px; border-radius: 50%;
+  background: var(--terracotta);
+}
+.cal-cell.is-today { border-color: var(--terracotta); color: var(--terracotta-2); }
+.cal-cell.is-selected { background: var(--terracotta); color: var(--paper); border-color: var(--terracotta); }
+.cal-cell.is-selected .cal-mark { background: var(--paper); }
+.cal-cell.is-selected.is-today { box-shadow: 0 0 0 2px var(--terracotta-3); }
+.cal-foot {
+  margin-top: var(--sp-4);
+  padding-top: var(--sp-3);
+  border-top: 1px dashed var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.cal-legend {
+  display: flex; gap: 14px;
+  font-family: var(--font-mono); font-size: 10px; color: var(--ink-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.cal-legend .lg { display: inline-flex; align-items: center; gap: 6px; }
+.cal-legend .lg .sw { width: 8px; height: 8px; border-radius: 50%; background: var(--terracotta); }
+.cal-legend .lg-today .sw { background: transparent; border: 1.5px solid var(--terracotta); width: 10px; height: 10px; }
+.cal-foot-meta {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--font-mono); font-size: 10px; color: var(--ink-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.cal-link {
+  background: none; border: none; padding: 0;
+  font-family: var(--font-mono); font-size: 10px;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--terracotta-2); cursor: pointer;
+  margin-left: 10px;
+}
+.cal-link:hover { color: var(--terracotta); text-decoration: underline; }
+
+/* selected-day filter bar */
+.filter-bar {
+  display: flex; justify-content: space-between; align-items: center;
+  gap: 12px; padding: 10px 14px;
+  background: var(--bg-elevated); border: 1px solid var(--border);
+  border-left: 3px solid var(--terracotta);
+  border-radius: var(--r-md);
+  margin-bottom: var(--sp-4);
+}
+.filter-bar-label { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.filter-bar-eye {
+  font-family: var(--font-mono); font-size: 10px; color: var(--ink-3);
+  letter-spacing: 0.14em; text-transform: uppercase;
+}
+.filter-bar-label em {
+  font-family: var(--font-display); font-style: italic;
+  font-size: 18px; color: var(--ink); letter-spacing: -0.01em;
+}
+.filter-bar-pill {
+  font-family: var(--font-mono); font-size: 9px; padding: 2px 7px;
+  border-radius: var(--r-pill);
+  background: var(--terracotta-3); color: var(--terracotta-2);
+  text-transform: uppercase; letter-spacing: 0.1em;
+}
+.filter-bar-clear {
+  background: none; border: none; cursor: pointer;
+  font-family: var(--font-mono); font-size: 11px;
+  letter-spacing: 0.06em; color: var(--ink-2);
+  padding: 0; white-space: nowrap;
+}
+.filter-bar-clear:hover { color: var(--terracotta); }
+
+/* empty day */
+.empty-day {
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-md);
+  padding: var(--sp-6) var(--sp-5);
+  text-align: center;
+  margin-top: var(--sp-3);
+  background: var(--paper-2);
+}
+.empty-day-mark {
+  font-family: var(--font-mono); font-size: 10px; color: var(--ink-3);
+  letter-spacing: 0.14em; text-transform: uppercase;
+  margin-bottom: var(--sp-2);
+}
+.empty-day p {
+  font-family: var(--font-display); font-size: 18px; color: var(--ink-2);
+  line-height: 1.5; margin: 0; max-width: 42ch; margin-left: auto; margin-right: auto;
+  text-wrap: pretty;
+}
+.empty-day p em { font-style: italic; color: var(--ink); }
+
+/* responsive — calendar drops below on narrow viewports */
+@media (max-width: 1080px) {
+  .entries-layout { grid-template-columns: 1fr; }
+  .cal { position: static; }
+}
+
 /* responsive */
 @media (max-width: 800px) {
   .app { grid-template-columns: 1fr; }

--- a/web/frontend/src/pages/Home.tsx
+++ b/web/frontend/src/pages/Home.tsx
@@ -2,6 +2,15 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router'
 import { api, type EntrySummary } from '../api/client'
 import { useNavCounts } from '../store/navCounts'
+import { EntryCalendar } from '../components/EntryCalendar'
+
+/** Returns a local-time ISO date string "YYYY-MM-DD" without UTC shift. */
+function toLocalISO(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
 
 function formatEntryDate(dateStr: string) {
   const d = new Date(dateStr + 'T12:00')
@@ -11,6 +20,11 @@ function formatEntryDate(dateStr: string) {
     monthShort: d.toLocaleDateString('en-US', { month: 'short' }),
     month: d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }),
   }
+}
+
+function formatSelectedLabel(dateStr: string): string {
+  const d = new Date(dateStr + 'T12:00')
+  return d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
 }
 
 function groupByMonth(entries: EntrySummary[]): Record<string, EntrySummary[]> {
@@ -30,6 +44,9 @@ function truncate(s: string, n: number): string {
 export function Home() {
   const [entries, setEntries] = useState<EntrySummary[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [selectedDate, setSelectedDate] = useState<string | null>(
+    () => toLocalISO(new Date()),
+  )
 
   useEffect(() => {
     let stale = false
@@ -48,7 +65,18 @@ export function Home() {
     }
   }, [])
 
-  const byMonth = entries ? groupByMonth(entries) : {}
+  const todayStr = toLocalISO(new Date())
+
+  const filtered = entries
+    ? selectedDate
+      ? entries.filter((e) => e.date === selectedDate)
+      : entries
+    : []
+
+  const byMonth = groupByMonth(filtered)
+
+  const selectedLabel = selectedDate ? formatSelectedLabel(selectedDate) : ''
+  const isToday = selectedDate === todayStr
 
   return (
     <>
@@ -73,44 +101,75 @@ export function Home() {
         </span>
       </div>
 
-      {entries?.length === 0 && (
-        <p style={{ color: 'var(--ink-3)' }}>
-          No entries yet. Start a journaling session in your AI assistant.
-        </p>
-      )}
-
-      {Object.entries(byMonth).map(([month, items]) => (
-        <div key={month}>
-          <div className="month-div">{month}</div>
-          {items.map((entry) => {
-            const { day, weekday, monthShort } = formatEntryDate(entry.date)
-            const title = truncate(entry.summary, 80)
-            const body = truncate(entry.summary, 200)
-
-            return (
-              <Link
-                key={entry.id}
-                to={`/app/entries/${entry.id}`}
-                style={{ textDecoration: 'none', color: 'inherit' }}
-              >
-                <div className="entry-row">
-                  <div className="entry-date">
-                    <span className="day">{day}</span>
-                    {monthShort} · {weekday}
-                  </div>
-                  <div className="entry-body">
-                    <h3>{title}</h3>
-                    <p>{body}</p>
-                  </div>
-                  <div className="entry-meta">
-                    {entry.mood && <span className="mood">◉ {entry.mood}</span>}
-                  </div>
+      {entries !== null && (
+        <div className="entries-layout">
+          <div className="entries-col">
+            {selectedDate && (
+              <div className="filter-bar">
+                <div className="filter-bar-label">
+                  <span className="filter-bar-eye">Showing</span>
+                  <em>{selectedLabel}</em>
+                  {isToday && <span className="filter-bar-pill">today</span>}
                 </div>
-              </Link>
-            )
-          })}
+                <button className="filter-bar-clear" onClick={() => setSelectedDate(null)}>
+                  Show all entries ›
+                </button>
+              </div>
+            )}
+
+            {entries.length === 0 && !selectedDate && (
+              <p style={{ color: 'var(--ink-3)' }}>
+                No entries yet. Start a journaling session in your AI assistant.
+              </p>
+            )}
+
+            {selectedDate && filtered.length === 0 ? (
+              <div className="empty-day">
+                <div className="empty-day-mark">— no entry —</div>
+                <p>
+                  Nothing was written on <em>{selectedLabel}</em>.{' '}
+                  {isToday && 'Open Kindred in Claude to start one.'}
+                </p>
+              </div>
+            ) : (
+              Object.entries(byMonth).map(([month, items]) => (
+                <div key={month}>
+                  <div className="month-div">{month}</div>
+                  {items.map((entry) => {
+                    const { day, weekday, monthShort } = formatEntryDate(entry.date)
+                    const title = truncate(entry.summary, 80)
+                    const body = truncate(entry.summary, 200)
+
+                    return (
+                      <Link
+                        key={entry.id}
+                        to={`/app/entries/${entry.id}`}
+                        style={{ textDecoration: 'none', color: 'inherit' }}
+                      >
+                        <div className="entry-row">
+                          <div className="entry-date">
+                            <span className="day">{day}</span>
+                            {monthShort} · {weekday}
+                          </div>
+                          <div className="entry-body">
+                            <h3>{title}</h3>
+                            <p>{body}</p>
+                          </div>
+                          <div className="entry-meta">
+                            {entry.mood && <span className="mood">◉ {entry.mood}</span>}
+                          </div>
+                        </div>
+                      </Link>
+                    )
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+
+          <EntryCalendar entries={entries} selected={selectedDate} onSelect={setSelectedDate} />
         </div>
-      ))}
+      )}
     </>
   )
 }

--- a/web/frontend/src/pages/Home.tsx
+++ b/web/frontend/src/pages/Home.tsx
@@ -117,13 +117,11 @@ export function Home() {
               </div>
             )}
 
-            {entries.length === 0 && !selectedDate && (
+            {entries.length === 0 ? (
               <p style={{ color: 'var(--ink-3)' }}>
                 No entries yet. Start a journaling session in your AI assistant.
               </p>
-            )}
-
-            {selectedDate && filtered.length === 0 ? (
+            ) : selectedDate && filtered.length === 0 ? (
               <div className="empty-day">
                 <div className="empty-day-mark">— no entry —</div>
                 <p>

--- a/web/frontend/src/pages/__tests__/Home.test.tsx
+++ b/web/frontend/src/pages/__tests__/Home.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 
 vi.mock('../../api/client', () => ({
@@ -76,6 +76,8 @@ describe('Home', () => {
         <Home />
       </MemoryRouter>,
     )
+    await waitFor(() => screen.getByText(/show all entries/i))
+    fireEvent.click(screen.getByText(/show all entries/i))
     await waitFor(() => {
       const matches = screen.getAllByText(/quiet morning/i)
       expect(matches.length).toBeGreaterThanOrEqual(2)
@@ -101,6 +103,8 @@ describe('Home', () => {
         <Home />
       </MemoryRouter>,
     )
+    await waitFor(() => screen.getByText(/show all entries/i))
+    fireEvent.click(screen.getByText(/show all entries/i))
     await waitFor(() => {
       expect(screen.getAllByText(/year end/i).length).toBeGreaterThanOrEqual(2)
     })


### PR DESCRIPTION
## Summary

- Adds `EntryCalendar.tsx` component: sticky 280px calendar rail with month navigation (‹/›), entry-dot indicators, today/selected highlight states, legend, "N this month" count, Today and Clear footer buttons
- Updates `Home.tsx`: `selectedDate` state (initialised to today), two-column `entries-layout` grid, filter bar showing the selected date label, empty-day state when no entry exists for the selected day
- Adds all calendar/layout CSS to `index.css` including a 1080px responsive breakpoint that collapses the grid to a single column

## Notes

- Uses a `toLocalISO()` helper (getFullYear/getMonth/getDate) throughout to avoid UTC timezone shift when building date strings — consistent with how entries use `date + 'T12:00'` for display
- `entries-layout` only renders after entries load (no layout shift during loading state)
- readonly-banner stays above the grid
- TypeScript strict — verified with `npm run build` (clean, zero errors)

## Test plan

- [ ] Home page shows two-column layout with calendar on the right
- [ ] Today is pre-selected on initial load; filter bar shows today's date with "today" pill
- [ ] Clicking a day with entries filters the list to that day
- [ ] Clicking the selected day deselects it (shows all entries)
- [ ] "Show all entries ›" clears the filter
- [ ] Days with entries have a terracotta dot below the number
- [ ] Empty day shows the "— no entry —" block with the selected date
- [ ] "Today" footer button navigates calendar to current month and selects today
- [ ] "Clear" footer button appears only when a date is selected, clears on click
- [ ] Month navigation (‹/›) changes the viewed month without affecting selection
- [ ] Responsive: at ≤1080px the calendar drops below the entries list

🤖 Generated with [Claude Code](https://claude.com/claude-code)