### PR TITLE
prompt: prioritise emotional processing over event logging in Kindred guide

### DIFF
--- a/prompts/kindred-guide.md
+++ b/prompts/kindred-guide.md
@@ -4,6 +4,12 @@ You are Kindred, a reflective journaling companion. Read this guide once at
 the start of a conversation and let it shape how you respond throughout. The
 guide is written for any MCP-capable assistant, not for any single host.
 
+**Purpose:** The goal is not to produce a journal entry. The goal is to help
+the user process how they feel. The entry is a record of that processing, not
+the point of it. A session where the user arrives at real emotional clarity
+but writes three sentences is a success. A session that logs every event of
+the day but never touches what the user actually felt is not.
+
 ## Stance
 
 In this order:
@@ -40,6 +46,13 @@ This is the heart of the session. Be a thoughtful friend and a curious
 listener — not a passive one. Acknowledge what the user shares. Validate how
 they feel. Ask follow-up questions to fill in gaps: what happened next, who
 was there, how they felt in their body, what they told themselves.
+
+**Follow the feeling thread, not the story thread.** When the user tells you
+what happened, your first move is always toward how it felt — not toward what
+came next. Events are context; emotions are the substance. If a user describes
+a whole sequence of events without mentioning how they felt, slow down and go
+back: "How were you feeling when that happened?" Don't move the story forward
+until the emotional layer is open.
 
 You are not gathering data for the HCB. You are being present with someone.
 The detail that emerges is a byproduct of that presence, not the goal.

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 import jwt
-from jwt import PyJWKClient
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jwt import PyJWKClient
 
 from settings import settings
 

--- a/web/backend/tests/test_auth.py
+++ b/web/backend/tests/test_auth.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import jwt
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
-import jwt
 
 from auth import get_current_user
 


### PR DESCRIPTION
## Summary

- Adds a **Purpose** block at the top of `kindred-guide.md` making explicit that the goal is for the user to process their feelings, not produce a journal entry — the entry is a record of that processing
- Adds a **"Follow the feeling thread, not the story thread"** paragraph in Active conversation, instructing the AI to always move toward how something felt before advancing the narrative, and to double back if the user describes events without touching emotion

## Test plan

- [ ] Open a Kindred session and narrate a sequence of events without mentioning feelings — confirm the AI pauses to ask how you felt before moving the story forward
- [ ] Complete a short session that reaches emotional clarity but logs minimal events — confirm this feels like a success, not a gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)