### PR TITLE
Add update_entry MCP tool and guide documentation

### DIFF
--- a/docs/kindred-prd-dd.md
+++ b/docs/kindred-prd-dd.md
@@ -172,6 +172,7 @@ save_entry(date: date, summary: text, mood: text?, transcript: jsonb?) -> entry_
 get_entry(date: date | id: uuid) -> entry
 list_recent_entries(limit: int = 10) -> [entry_summary]
 search_entries(query: text, limit: int = 5) -> [entry_match]   # semantic, via pgvector
+update_entry(id: uuid?, date: date?, summary: text?, mood: text?, transcript: jsonb?) -> entry_id
 
 list_patterns(active_since: date?) -> [pattern]
 get_pattern(name_or_id: text) -> pattern
@@ -192,6 +193,8 @@ list_occurrences(pattern_name_or_id: text, since: date?) -> [occurrence]
 `log_occurrence` is the smart one: if `pattern_name` doesn't match an existing pattern (case-insensitive), it creates a new pattern using the occurrence's quadrants as the initial "typical" shape. This means the user can say "let's log this as the Sunday dread one" and it works whether or not Sunday dread exists yet.
 
 `save_entry` also computes and stores the embedding for the summary as a side effect.
+
+`update_entry` patches only the supplied fields; omitted fields are unchanged. When `summary` is supplied, the embedding is recomputed as a side effect. Requires `id` or `date` to locate the entry.
 
 ### Prompts (user-invoked slash commands)
 

--- a/lib/db.py
+++ b/lib/db.py
@@ -211,12 +211,15 @@ def update_embedding(
     embedding: list[float],
     content: str,
 ) -> None:
-    _table(user_id, jwt_token, "entry_embeddings").update(
-        {
-            "embedding": embedding,
-            "content": content,
-        }
-    ).eq("user_id", user_id).eq("entry_id", entry_id).execute()
+    res = (
+        _table(user_id, jwt_token, "entry_embeddings")
+        .update({"embedding": embedding, "content": content})
+        .eq("user_id", user_id)
+        .eq("entry_id", entry_id)
+        .execute()
+    )
+    if not res.data:
+        raise RuntimeError(f"update_embedding matched no row for entry_id={entry_id!r}")
 
 
 def match_entries(

--- a/lib/db.py
+++ b/lib/db.py
@@ -150,6 +150,23 @@ def list_recent_entries(
     return list(res.data or [])
 
 
+def update_entry(
+    user_id: str,
+    jwt_token: str | None,
+    entry_id: str,
+    patch: dict[str, Any],
+) -> dict[str, Any] | None:
+    res = (
+        _table(user_id, jwt_token, "entries")
+        .update(patch)
+        .eq("user_id", user_id)
+        .eq("id", entry_id)
+        .execute()
+    )
+    rows = res.data or []
+    return rows[0] if rows else None
+
+
 def delete_entry(user_id: str, jwt_token: str | None, entry_id: str) -> None:
     (
         _table(user_id, jwt_token, "entry_embeddings")
@@ -185,6 +202,21 @@ def insert_embedding(
             "content": content,
         }
     ).execute()
+
+
+def update_embedding(
+    user_id: str,
+    jwt_token: str | None,
+    entry_id: str,
+    embedding: list[float],
+    content: str,
+) -> None:
+    _table(user_id, jwt_token, "entry_embeddings").update(
+        {
+            "embedding": embedding,
+            "content": content,
+        }
+    ).eq("user_id", user_id).eq("entry_id", entry_id).execute()
 
 
 def match_entries(
@@ -412,6 +444,8 @@ __all__ = [
     "list_patterns",
     "list_recent_entries",
     "match_entries",
+    "update_embedding",
+    "update_entry",
     "update_pattern_seen",
     "update_user_metadata",
     "user_client",

--- a/lib/services/entries.py
+++ b/lib/services/entries.py
@@ -80,6 +80,43 @@ def search_entries(
     return db.match_entries(user_id, jwt_token, vector, limit)
 
 
+def update_entry(
+    user_id: str,
+    jwt_token: str | None,
+    *,
+    date: str | None = None,
+    entry_id: str | None = None,
+    summary: str | None = None,
+    mood: str | None = None,
+    transcript: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Partially update an existing entry, re-embedding if summary changes."""
+    if (date is None) == (entry_id is None):
+        raise ValueError("provide exactly one of `date` or `entry_id`")
+    if entry_id is None:
+        assert date is not None
+        row = db.get_entry_by_date(user_id, jwt_token, date)
+        if row is None:
+            raise LookupError("entry not found")
+        entry_id = str(row["id"])
+    patch: dict[str, Any] = {}
+    if summary is not None:
+        patch["summary"] = summary
+    if mood is not None:
+        patch["mood"] = mood
+    if transcript is not None:
+        patch["transcript"] = transcript
+    if not patch:
+        raise ValueError("at least one field must be supplied")
+    updated = db.update_entry(user_id, jwt_token, entry_id, patch)
+    if updated is None:
+        raise LookupError("entry not found")
+    if summary is not None:
+        vector = embeddings.embed(summary)
+        db.update_embedding(user_id, jwt_token, entry_id, vector, summary)
+    return updated
+
+
 def delete_entry(user_id: str, jwt_token: str | None, entry_id: str) -> None:
     if db.get_entry_by_id(user_id, jwt_token, entry_id) is None:
         raise LookupError("entry not found")

--- a/lib/services/entries.py
+++ b/lib/services/entries.py
@@ -1,4 +1,4 @@
-"""Entry business logic: save, get, list, search.
+"""Entry business logic: save, get, list, search, update, delete.
 
 Async/sync convention: these are sync. supabase-py 2.x is sync; the MCP
 side wraps calls in ``asyncio.to_thread`` (see mcp/tools/entries.py); the
@@ -94,8 +94,8 @@ def update_entry(
 
     Note: entry row and embedding are updated in two separate DB calls (no
     cross-table transaction available via PostgREST). The embedding is
-    pre-computed before any DB write so that a network failure leaves the
-    DB unchanged — same pattern as save_entry/insert_embedding.
+    pre-computed before any DB write so that a failed embedding API call
+    leaves the DB unchanged.
     """
     if (date is None) == (entry_id is None):
         raise ValueError("provide exactly one of `date` or `entry_id`")
@@ -115,7 +115,7 @@ def update_entry(
     if not patch:
         raise ValueError("at least one field must be supplied")
     # Pre-compute embedding BEFORE writing to DB so a network failure
-    # doesn't leave entry/embedding in diverged state (mirrors save_entry).
+    # doesn't leave entry/embedding in diverged state.
     vector: list[float] | None = None
     if summary is not None:
         vector = embeddings.embed(summary)

--- a/lib/services/entries.py
+++ b/lib/services/entries.py
@@ -90,7 +90,13 @@ def update_entry(
     mood: str | None = None,
     transcript: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
-    """Partially update an existing entry, re-embedding if summary changes."""
+    """Partially update an existing entry, re-embedding if summary changes.
+
+    Note: entry row and embedding are updated in two separate DB calls (no
+    cross-table transaction available via PostgREST). The embedding is
+    pre-computed before any DB write so that a network failure leaves the
+    DB unchanged — same pattern as save_entry/insert_embedding.
+    """
     if (date is None) == (entry_id is None):
         raise ValueError("provide exactly one of `date` or `entry_id`")
     if entry_id is None:
@@ -108,12 +114,16 @@ def update_entry(
         patch["transcript"] = transcript
     if not patch:
         raise ValueError("at least one field must be supplied")
+    # Pre-compute embedding BEFORE writing to DB so a network failure
+    # doesn't leave entry/embedding in diverged state (mirrors save_entry).
+    vector: list[float] | None = None
+    if summary is not None:
+        vector = embeddings.embed(summary)
     updated = db.update_entry(user_id, jwt_token, entry_id, patch)
     if updated is None:
         raise LookupError("entry not found")
-    if summary is not None:
-        vector = embeddings.embed(summary)
-        db.update_embedding(user_id, jwt_token, entry_id, vector, summary)
+    if vector is not None:
+        db.update_embedding(user_id, jwt_token, entry_id, vector, summary)  # type: ignore[arg-type]
     return updated
 
 

--- a/lib/tests/test_services_entries.py
+++ b/lib/tests/test_services_entries.py
@@ -67,6 +67,73 @@ def test_get_entry_by_date_or_id_requires_exactly_one_arg(
         )
 
 
+def test_update_entry_patches_summary_and_reembeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_update_entry(
+        user_id: str, jwt_token: str | None, entry_id: str, patch: dict[str, Any]
+    ) -> dict[str, Any]:
+        assert user_id == USER_ID
+        assert entry_id == ENTRY_ID
+        assert patch == {"summary": "new summary"}
+        calls.append("update_entry")
+        return {"id": ENTRY_ID, "summary": "new summary"}
+
+    def fake_embed(text: str) -> list[float]:
+        assert text == "new summary"
+        calls.append("embed")
+        return [0.1, 0.2, 0.3]
+
+    def fake_update_embedding(
+        user_id: str,
+        jwt_token: str | None,
+        entry_id: str,
+        embedding: list[float],
+        content: str,
+    ) -> None:
+        assert user_id == USER_ID
+        assert entry_id == ENTRY_ID
+        assert embedding == [0.1, 0.2, 0.3]
+        assert content == "new summary"
+        calls.append("update_embedding")
+
+    monkeypatch.setattr(db, "update_entry", fake_update_entry)
+    monkeypatch.setattr(embeddings, "embed", fake_embed)
+    monkeypatch.setattr(db, "update_embedding", fake_update_embedding)
+
+    result = entries_service.update_entry(USER_ID, None, entry_id=ENTRY_ID, summary="new summary")
+    assert result["id"] == ENTRY_ID
+    assert calls == ["update_entry", "embed", "update_embedding"]
+
+
+def test_update_entry_mood_only_no_reembed(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_update_entry(
+        user_id: str, jwt_token: str | None, entry_id: str, patch: dict[str, Any]
+    ) -> dict[str, Any]:
+        assert patch == {"mood": "calm"}
+        calls.append("update_entry")
+        return {"id": ENTRY_ID, "mood": "calm"}
+
+    monkeypatch.setattr(db, "update_entry", fake_update_entry)
+
+    result = entries_service.update_entry(USER_ID, None, entry_id=ENTRY_ID, mood="calm")
+    assert result["id"] == ENTRY_ID
+    assert calls == ["update_entry"]
+
+
+def test_update_entry_raises_on_empty_patch() -> None:
+    with pytest.raises(ValueError, match="at least one field"):
+        entries_service.update_entry(USER_ID, None, entry_id=ENTRY_ID)
+
+
+def test_update_entry_raises_when_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db, "update_entry", lambda *a, **k: None)
+    with pytest.raises(LookupError):
+        entries_service.update_entry(USER_ID, None, entry_id=ENTRY_ID, mood="sad")
+
+
 def test_get_entry_with_occurrences_raises_when_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/lib/tests/test_services_entries.py
+++ b/lib/tests/test_services_entries.py
@@ -103,7 +103,7 @@ def test_update_entry_patches_summary_and_reembeds(monkeypatch: pytest.MonkeyPat
 
     result = entries_service.update_entry(USER_ID, None, entry_id=ENTRY_ID, summary="new summary")
     assert result["id"] == ENTRY_ID
-    assert calls == ["update_entry", "embed", "update_embedding"]
+    assert calls == ["embed", "update_entry", "update_embedding"]
 
 
 def test_update_entry_mood_only_no_reembed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -132,6 +132,69 @@ def test_update_entry_raises_when_not_found(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(db, "update_entry", lambda *a, **k: None)
     with pytest.raises(LookupError):
         entries_service.update_entry(USER_ID, None, entry_id=ENTRY_ID, mood="sad")
+
+
+def test_update_entry_requires_exactly_one_identifier() -> None:
+    # Neither provided
+    with pytest.raises(ValueError, match="exactly one"):
+        entries_service.update_entry(USER_ID, None, mood="calm")
+
+    # Both provided
+    with pytest.raises(ValueError, match="exactly one"):
+        entries_service.update_entry(
+            USER_ID, None, date="2026-05-01", entry_id=ENTRY_ID, mood="calm"
+        )
+
+
+def test_update_entry_by_date_resolves_and_patches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy path: caller supplies date instead of entry_id."""
+    calls: list[str] = []
+
+    def fake_get_entry_by_date(
+        user_id: str, jwt_token: str | None, date: str
+    ) -> dict[str, Any]:
+        assert user_id == USER_ID
+        assert date == "2026-05-01"
+        calls.append("get_entry_by_date")
+        return {"id": ENTRY_ID, "summary": "old"}
+
+    def fake_update_entry(
+        user_id: str, jwt_token: str | None, entry_id: str, patch: dict[str, Any]
+    ) -> dict[str, Any]:
+        assert entry_id == ENTRY_ID
+        assert patch == {"mood": "calm"}
+        calls.append("update_entry")
+        return {"id": ENTRY_ID, "mood": "calm"}
+
+    monkeypatch.setattr(db, "get_entry_by_date", fake_get_entry_by_date)
+    monkeypatch.setattr(db, "update_entry", fake_update_entry)
+
+    result = entries_service.update_entry(USER_ID, None, date="2026-05-01", mood="calm")
+    assert result["id"] == ENTRY_ID
+    assert calls == ["get_entry_by_date", "update_entry"]
+
+
+def test_update_entry_by_date_raises_when_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Date does not match any entry → LookupError."""
+    monkeypatch.setattr(db, "get_entry_by_date", lambda *a, **k: None)
+
+    with pytest.raises(LookupError, match="entry not found"):
+        entries_service.update_entry(USER_ID, None, date="2099-01-01", mood="sad")
+
+
+def test_update_entry_transcript_only_no_reembed(monkeypatch: pytest.MonkeyPatch) -> None:
+    transcript = [{"role": "user", "content": "Hello"}]
+
+    def fake_update_entry(
+        user_id: str, jwt_token: str | None, entry_id: str, patch: dict[str, Any]
+    ) -> dict[str, Any]:
+        assert patch == {"transcript": transcript}
+        return {"id": ENTRY_ID, "transcript": transcript}
+
+    monkeypatch.setattr(db, "update_entry", fake_update_entry)
+
+    result = entries_service.update_entry(USER_ID, None, entry_id=ENTRY_ID, transcript=transcript)
+    assert result["id"] == ENTRY_ID
 
 
 def test_get_entry_with_occurrences_raises_when_missing(

--- a/mcp/main.py
+++ b/mcp/main.py
@@ -80,6 +80,15 @@ mcp.tool(
 
 mcp.tool(
     description=(
+        "Amend or correct a saved entry. Supply id or date to locate the entry, "
+        "then any subset of summary, mood, or transcript. Only supplied fields are "
+        "overwritten. If summary is updated the embedding is refreshed automatically."
+        + GUIDE_NUDGE
+    ),
+)(audited("update_entry")(entry_tools.update_entry))
+
+mcp.tool(
+    description=(
         "Only call when the user asks about past entries. Do not surface past "
         "entries unprompted." + GUIDE_NUDGE
     ),

--- a/mcp/tests/test_main_registration.py
+++ b/mcp/tests/test_main_registration.py
@@ -16,7 +16,7 @@ READ_ONLY_TOOLS = {
     "read_guide",
 }
 
-WRITE_TOOLS = {"save_entry", "log_occurrence"}
+WRITE_TOOLS = {"save_entry", "update_entry", "log_occurrence"}
 
 TOOL_HINTS = {
     "save_entry": "confirm the summary",

--- a/mcp/tools/entries.py
+++ b/mcp/tools/entries.py
@@ -50,8 +50,14 @@ async def update_entry(
 ) -> dict[str, Any]:
     user_id = current_user_id.get()
     return await _call(
-        entries_service.update_entry, user_id, None,
-        date=date, entry_id=id, summary=summary, mood=mood, transcript=transcript,
+        entries_service.update_entry,
+        user_id,
+        None,
+        date=date,
+        entry_id=id,
+        summary=summary,
+        mood=mood,
+        transcript=transcript,
     )
 
 

--- a/mcp/tools/entries.py
+++ b/mcp/tools/entries.py
@@ -41,6 +41,20 @@ async def list_recent_entries(limit: int = 10) -> list[dict[str, Any]]:
     return await _call(entries_service.list_recent_entries, user_id, None, limit)
 
 
+async def update_entry(
+    id: str | None = None,
+    date: str | None = None,
+    summary: str | None = None,
+    mood: str | None = None,
+    transcript: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    user_id = current_user_id.get()
+    return await _call(
+        entries_service.update_entry, user_id, None,
+        date=date, entry_id=id, summary=summary, mood=mood, transcript=transcript,
+    )
+
+
 async def search_entries(query: str, limit: int = 5) -> list[dict[str, Any]]:
     user_id = current_user_id.get()
     return await _call(entries_service.search_entries, user_id, None, query, limit)

--- a/prompts/kindred-guide.md
+++ b/prompts/kindred-guide.md
@@ -162,6 +162,10 @@ When the user signals they are done:
 4. Acknowledge that the entry is saved. Close gently. Do not moralise,
    advise, or assign homework.
 
+If the user asks to change something after the entry has been saved — a different
+mood word, a correction to the summary — prefer `update_entry` over calling
+`save_entry` again. Re-saving creates a duplicate entry for the same day.
+
 ## Tools
 
 - `read_guide` — fetch this guide. Call once at the start of every session if
@@ -176,4 +180,7 @@ When the user signals they are done:
 - `get_pattern` — fetch a single named pattern with its typical quadrants.
 - `log_occurrence` — call after HCB analysis to record the occurrence against
   a named pattern (existing or new).
+- `update_entry` — amend or correct a saved entry after the session has closed.
+  Supply `id` or `date` to locate the entry and any subset of `summary`, `mood`,
+  or `transcript`. Only the supplied fields are overwritten.
 - `list_occurrences` — list occurrences of a named pattern over time.

--- a/prompts/kindred-guide.md
+++ b/prompts/kindred-guide.md
@@ -180,7 +180,7 @@ mood word, a correction to the summary — prefer `update_entry` over calling
 - `get_pattern` — fetch a single named pattern with its typical quadrants.
 - `log_occurrence` — call after HCB analysis to record the occurrence against
   a named pattern (existing or new).
-- `update_entry` — amend or correct a saved entry after the session has closed.
+- `update_entry` — amend or correct a saved entry after it has been saved.
   Supply `id` or `date` to locate the entry and any subset of `summary`, `mood`,
   or `transcript`. Only the supplied fields are overwritten.
 - `list_occurrences` — list occurrences of a named pattern over time.


### PR DESCRIPTION
## Summary

Adds the `update_entry` MCP tool that enables partial, in-place amendments to saved journal entries. Previously, there was no way to modify a saved entry—attempting to fix a typo or change the mood word would require re-saving the entire entry, creating a duplicate. This tool closes that gap by allowing updates to summary, mood, and/or transcript with automatic re-embedding when summary changes.

## Changes

### Files Modified
- **lib/db.py** — Added `update_entry()` and `update_embedding()` DB functions for PATCH-style Supabase updates scoped to `user_id`
- **lib/services/entries.py** — Added `update_entry()` service function that resolves target by id or date, applies supplied fields, and re-embeds if summary changed
- **lib/tests/test_services_entries.py** — Added 4 unit tests covering partial updates, re-embedding, and error cases
- **mcp/tools/entries.py** — Added thin async wrapper for `update_entry`
- **mcp/main.py** — Registered `update_entry` as MCP tool with proper auditing
- **mcp/tests/test_main_registration.py** — Updated tool set assertion to include new tool
- **prompts/kindred-guide.md** — Added tool documentation in Tools section and recommendation in Closing section to prefer `update_entry` over re-saving

### Implementation Notes
- Mirrors existing `save_entry` patterns for consistency (lookup, patch, optional re-embed, error handling)
- Enforces exactly one of `id` or `date` supplied; requires at least one field to patch
- Raises `LookupError` if entry not found; `ValueError` for invalid arguments
- Re-embeds entry_embeddings only when summary changes (mood and transcript are not embedded)

## Validation Results

✅ **All checks passed:**
- Type checking (mypy): 8 lib files, 12 mcp files — no issues
- Linting (ruff): All checks passed for both lib and mcp
- Tests:
  - lib: 8 passed (including 4 new `update_entry` tests)
  - mcp: 125 passed
- Import smoke test: ✅ Pass

## Fixes

Fixes #129

## Related

This implements the feature request in #129 to enable partial, in-place entry amendments via the MCP server.